### PR TITLE
Feat: vmix connection

### DIFF
--- a/client/components/Channel.tsx
+++ b/client/components/Channel.tsx
@@ -134,7 +134,7 @@ class Channel extends React.Component<
     }
 
     handleVuMeter() {
-        if (window.mixerProtocol.protocol === 'CasparCG') {
+        if (window.mixerProtocol.protocol === 'CasparCG' || window.mixerProtocol.protocol === 'VMIX') {
             return (
                 <React.Fragment>
                     {!window.location.search.includes('vu=0') &&

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         ]
     },
     "dependencies": {
+        "add": "^2.0.6",
         "asn1": "github:evs-broadcast/node-asn1",
         "bufferutil": "^4.0.3",
         "casparcg-connection": "^5.1.0",
@@ -85,10 +86,12 @@
         "socket.io": "^4.0.0",
         "socket.io-client": "^4.0.0",
         "utf-8-validate": "^5.0.4",
+        "vmix-js-utils": "^4.0.6",
         "web-midi-api": "^2.0.8",
         "webmidi": "^2.5.2",
         "winston": "^3.3.3",
-        "winston-elasticsearch": "^0.15.2"
+        "winston-elasticsearch": "^0.15.2",
+        "yarn": "^1.22.10"
     },
     "devDependencies": {
         "@babel/core": "^7.13.10",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "i18next-browser-languagedetector": "^6.1.1",
         "jquery": "^3.6.0",
         "node-emberplus": "https://github.com/olzzon/node-emberplus#feat/export-ber",
+        "node-vmix": "^1.5.2",
         "nouislider": "^14.6.3",
         "nouislider-react": "^3.4.0",
         "osc": "https://github.com/olzzon/tv2-osc.js-no-serialport.git",

--- a/server/constants/MixerProtocolPresets.ts
+++ b/server/constants/MixerProtocolPresets.ts
@@ -12,6 +12,7 @@ import { YamahaQLCL } from './mixerProtocols/yamahaQLCL'
 import { SSLSystemT } from './mixerProtocols/SSLsystemT'
 import { StuderOnAirMaster } from './mixerProtocols/StuderOnAirEmber'
 import { StuderVistaMaster } from './mixerProtocols/StuderVistaEmber'
+import { VMix } from './mixerProtocols/vMix'
 
 // Interface:
 import { IMixerProtocolGeneric } from './MixerProtocolInterface'
@@ -33,6 +34,7 @@ export const MixerProtocolPresets: {
         sslSystemT: SSLSystemT,
         studerOnAirMaster: StuderOnAirMaster,
         studerVistaMaster: StuderVistaMaster,
+        vMix: VMix,
     },
     {
         casparCGMaster: CasparCGMaster,

--- a/server/constants/mixerProtocols/vMix.ts
+++ b/server/constants/mixerProtocols/vMix.ts
@@ -13,102 +13,105 @@ export const VMix: IMixerProtocol = {
     FADE_DISPATCH_RESOLUTION: 5,
     leadingZeros: true,
     pingCommand: [
-        {
-            mixerMessage: '/xremote',
-        },
-        {
-            mixerMessage: '/meters',
-            value: '/meters/1',
-            type: 's',
-        },
+        // {
+        //     mixerMessage: '/xremote',
+        // },
+        // {
+        //     mixerMessage: '/meters',
+        //     value: '/meters/1',
+        //     type: 's',
+        // },
     ],
     pingTime: 9500,
     initializeCommands: [
         {
-            mixerMessage: '/ch/{channel}/mix/fader',
+            mixerMessage: 'SetVolume',
         },
         {
-            mixerMessage: '/ch/{channel}/config/name',
+            mixerMessage: 'AudioAutoOff',
         },
-        {
-            mixerMessage: '/ch/{channel}/mix/{argument}/level',
-            type: 'aux',
-        },
-        {
-            mixerMessage: '/ch/{channel}/preamp/trim',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/thr',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/ratio',
-        },
-        {
-            mixerMessage: '/ch/{channel}/delay/time',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/1/g',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/2/g',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/3/g',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/4/g',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/thr',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/ratio',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/attack',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/hold',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/knee',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/mgain',
-        },
-        {
-            mixerMessage: '/ch/{channel}/dyn/ratio',
-        },
-        {
-            mixerMessage: '/ch/{channel}/delay/time',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/1/g',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/1/f',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/2/f',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/3/f',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/4/f',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/1/q',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/2/q',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/3/q',
-        },
-        {
-            mixerMessage: '/ch/{channel}/eq/4/q',
-        },
+        // {
+        //     mixerMessage: '/ch/{channel}/config/name',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/mix/{argument}/level',
+        //     type: 'aux',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/preamp/trim',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/thr',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/ratio',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/delay/time',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/1/g',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/2/g',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/3/g',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/4/g',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/thr',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/ratio',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/attack',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/hold',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/knee',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/mgain',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/dyn/ratio',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/delay/time',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/1/g',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/1/f',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/2/f',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/3/f',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/4/f',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/1/q',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/2/q',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/3/q',
+        // },
+        // {
+        //     mixerMessage: '/ch/{channel}/eq/4/q',
+        // },
     ],
     channelTypes: [
         {
@@ -117,201 +120,24 @@ export const VMix: IMixerProtocol = {
             fromMixer: {
                 CHANNEL_OUT_GAIN: [
                     {
-                        mixerMessage: '/ch/{channel}/mix/fader',
+                        mixerMessage: 'SetVolume',
                     },
                 ],
                 CHANNEL_VU: [
                     {
                         mixerMessage: '/meters/1',
                     },
-                ],
-                [fxParamsList.GainTrim]: [
                     {
-                        mixerMessage: '/ch/{channel}/preamp/trim',
-                        minLabel: -18,
-                        maxLabel: 18,
-                        label: 'Gain Trim',
-                        valueLabel: ' dB',
+                        mixerMessage: '/meters/2',
                     },
                 ],
-                [fxParamsList.CompThrs]: [
+                CHANNEL_INPUT_GAIN: [
                     {
-                        mixerMessage: '/ch/{channel}/dyn/thr',
-                        minLabel: -60,
-                        maxLabel: 0,
-                        label: 'Threshold',
-                        valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.CompRatio]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/ratio',
-                        minLabel: 1,
-                        maxLabel: 10,
-                        label: 'Ratio',
-                        valueLabel: ' :1',
-                    },
-                ],
-                [fxParamsList.CompAttack]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/attack',
-                        minLabel: 0,
-                        maxLabel: 120,
-                        label: 'Attack',
-                        valueLabel: ' ms',
-                    },
-                ],
-                [fxParamsList.CompHold]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/hold',
-                        minLabel: 0,
-                        maxLabel: 2000,
-                        label: 'Hold',
-                        valueLabel: ' ms',
-                    },
-                ],
-                [fxParamsList.CompKnee]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/knee',
-                        minLabel: 0,
-                        maxLabel: 5,
-                        label: 'Knee',
-                        valueLabel: ' ',
-                    },
-                ],
-                [fxParamsList.CompMakeUp]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/mgain',
+                        mixerMessage: 'SetGain',
                         minLabel: 0,
                         maxLabel: 24,
-                        label: 'MakeUp',
+                        label: 'Gain Trim',
                         valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.CompRelease]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/release',
-                        minLabel: 5,
-                        maxLabel: 4000,
-                        label: 'Release',
-                        valueLabel: ' ms',
-                    },
-                ],
-                [fxParamsList.DelayTime]: [
-                    {
-                        mixerMessage: '/ch/{channel}/delay/time',
-                        minLabel: 0,
-                        maxLabel: 500,
-                        label: 'Time',
-                        valueLabel: ' ms',
-                    },
-                ],
-                [fxParamsList.EqGain01]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/1/g',
-                        minLabel: -15,
-                        maxLabel: 15,
-                        label: 'Low',
-                        valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.EqGain02]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/2/g',
-                        minLabel: -15,
-                        maxLabel: 15,
-                        label: 'LoMid',
-                        valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.EqGain03]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/3/g',
-                        minLabel: -15,
-                        maxLabel: 15,
-                        label: 'HiMid',
-                        valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.EqGain04]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/4/g',
-                        minLabel: -15,
-                        maxLabel: 15,
-                        label: 'High',
-                        valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.EqFreq01]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/1/f',
-                        minLabel: 20,
-                        maxLabel: 20000,
-                        label: 'Low Freq',
-                        valueLabel: ' Freq',
-                    },
-                ],
-                [fxParamsList.EqFreq02]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/2/f',
-                        minLabel: 20,
-                        maxLabel: 20000,
-                        label: 'LoMid freq',
-                        valueLabel: ' Freq',
-                    },
-                ],
-                [fxParamsList.EqFreq03]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/3/f',
-                        minLabel: 20,
-                        maxLabel: 20000,
-                        label: 'HiMid freq',
-                        valueLabel: ' Freq',
-                    },
-                ],
-                [fxParamsList.EqFreq04]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/4/f',
-                        minLabel: 20,
-                        maxLabel: 20000,
-                        label: 'High freq',
-                        valueLabel: ' Freq',
-                    },
-                ],
-                [fxParamsList.EqQ01]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/1/q',
-                        minLabel: 10,
-                        maxLabel: 0.3,
-                        label: 'Low Q',
-                        valueLabel: ' Q',
-                    },
-                ],
-                [fxParamsList.EqQ02]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/2/q',
-                        minLabel: 10,
-                        maxLabel: 0.3,
-                        label: 'LoMid Q',
-                        valueLabel: ' Q',
-                    },
-                ],
-                [fxParamsList.EqQ03]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/3/q',
-                        minLabel: 10,
-                        maxLabel: 0.3,
-                        label: 'HiMid Q',
-                        valueLabel: ' Q',
-                    },
-                ],
-                [fxParamsList.EqQ04]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/4/q',
-                        minLabel: 10,
-                        maxLabel: 0.3,
-                        label: 'High Q',
-                        valueLabel: ' Q',
                     },
                 ],
                 AUX_LEVEL: [
@@ -328,135 +154,68 @@ export const VMix: IMixerProtocol = {
             toMixer: {
                 CHANNEL_OUT_GAIN: [
                     {
-                        mixerMessage: '/ch/{channel}/mix/fader',
+                        mixerMessage: 'SetVolume',
                     },
                 ],
-                [fxParamsList.GainTrim]: [
+                CHANNEL_INPUT_SELECTOR: [
                     {
-                        mixerMessage: '/ch/{channel}/preamp/trim',
-                        minLabel: -18,
-                        maxLabel: 18,
+                        mixerMessage: 'AudioChannelMatrixApplyPreset',
+                        label: 'LR',
+                        value: 'Default',
+                    },
+                    {
+                        mixerMessage: 'AudioChannelMatrixApplyPreset',
+                        label: 'LL',
+                        value: 'LL',
+                    },
+                    {
+                        mixerMessage: 'AudioChannelMatrixApplyPreset',
+                        label: 'RR',
+                        value: 'RR',
+                    },
+                ],
+                CHANNEL_INPUT_GAIN: [
+                    {
+                        mixerMessage: 'SetGain',
+                        minLabel: 0,
+                        maxLabel: 24,
                         label: 'Gain Trim',
                         valueLabel: ' dB',
-                    },
-                ],
-                [fxParamsList.CompThrs]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/thr',
-                    },
-                ],
-                [fxParamsList.CompRatio]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/ratio',
-                    },
-                ],
-                [fxParamsList.CompAttack]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/attack',
-                    },
-                ],
-                [fxParamsList.CompHold]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/hold',
-                    },
-                ],
-                [fxParamsList.CompKnee]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/knee',
-                    },
-                ],
-                [fxParamsList.CompMakeUp]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/mgain',
-                    },
-                ],
-                [fxParamsList.CompRelease]: [
-                    {
-                        mixerMessage: '/ch/{channel}/dyn/release',
-                    },
-                ],
-                [fxParamsList.DelayTime]: [
-                    {
-                        mixerMessage: '/ch/{channel}/delay/time',
-                    },
-                ],
-                [fxParamsList.EqGain01]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/1/g',
-                    },
-                ],
-                [fxParamsList.EqGain02]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/2/g',
-                    },
-                ],
-                [fxParamsList.EqGain03]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/3/g',
-                    },
-                ],
-                [fxParamsList.EqGain04]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/4/g',
-                    },
-                ],
-                [fxParamsList.EqFreq01]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/1/f',
-                    },
-                ],
-                [fxParamsList.EqFreq02]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/2/f',
-                    },
-                ],
-                [fxParamsList.EqFreq03]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/3/f',
-                    },
-                ],
-                [fxParamsList.EqFreq04]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/4/f',
-                    },
-                ],
-                [fxParamsList.EqQ01]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/1/q',
-                    },
-                ],
-                [fxParamsList.EqQ02]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/2/q',
-                    },
-                ],
-                [fxParamsList.EqQ03]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/3/q',
-                    },
-                ],
-                [fxParamsList.EqQ04]: [
-                    {
-                        mixerMessage: '/ch/{channel}/eq/4/q',
-                    },
-                ],
-                AUX_LEVEL: [
-                    {
-                        mixerMessage: '/ch/{channel}/mix/{argument}/level',
+                        min: 0,
+                        max: 24,
                     },
                 ],
                 CHANNEL_MUTE_ON: [
                     {
-                        mixerMessage: '/ch/{channel}/mix/on',
+                        mixerMessage: 'AudioOff',
                         value: 0,
                         type: 'f',
                     },
                 ],
                 CHANNEL_MUTE_OFF: [
                     {
-                        mixerMessage: '/ch/{channel}/mix/on',
+                        mixerMessage: 'AudioOn',
                         value: 1,
                         type: 'f',
+                    },
+                ],
+                PFL_OFF: [
+                    {
+                        mixerMessage: 'SoloOff',
+                        value: 1,
+                        type: 'f',
+                    },
+                ],
+                PFL_ON: [
+                    {
+                        mixerMessage: 'SoloOn',
+                        value: 1,
+                        type: 'f',
+                    },
+                ],
+                AUX_LEVEL: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/{argument}/level',
                     },
                 ],
             },

--- a/server/constants/mixerProtocols/vMix.ts
+++ b/server/constants/mixerProtocols/vMix.ts
@@ -1,0 +1,477 @@
+import { IMixerProtocol, fxParamsList } from '../MixerProtocolInterface'
+
+export const VMix: IMixerProtocol = {
+    protocol: 'VMIX',
+    fxList: fxParamsList,
+    label: 'VMix Audio Control',
+    presetFileExtension: 'vmix',
+    loadPresetCommand: [
+        {
+            mixerMessage: '/load',
+        },
+    ],
+    FADE_DISPATCH_RESOLUTION: 5,
+    leadingZeros: true,
+    pingCommand: [
+        {
+            mixerMessage: '/xremote',
+        },
+        {
+            mixerMessage: '/meters',
+            value: '/meters/1',
+            type: 's',
+        },
+    ],
+    pingTime: 9500,
+    initializeCommands: [
+        {
+            mixerMessage: '/ch/{channel}/mix/fader',
+        },
+        {
+            mixerMessage: '/ch/{channel}/config/name',
+        },
+        {
+            mixerMessage: '/ch/{channel}/mix/{argument}/level',
+            type: 'aux',
+        },
+        {
+            mixerMessage: '/ch/{channel}/preamp/trim',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/thr',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/ratio',
+        },
+        {
+            mixerMessage: '/ch/{channel}/delay/time',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/1/g',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/2/g',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/3/g',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/4/g',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/thr',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/ratio',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/attack',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/hold',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/knee',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/mgain',
+        },
+        {
+            mixerMessage: '/ch/{channel}/dyn/ratio',
+        },
+        {
+            mixerMessage: '/ch/{channel}/delay/time',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/1/g',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/1/f',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/2/f',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/3/f',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/4/f',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/1/q',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/2/q',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/3/q',
+        },
+        {
+            mixerMessage: '/ch/{channel}/eq/4/q',
+        },
+    ],
+    channelTypes: [
+        {
+            channelTypeName: 'CH',
+            channelTypeColor: '#2f2f2f',
+            fromMixer: {
+                CHANNEL_OUT_GAIN: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/fader',
+                    },
+                ],
+                CHANNEL_VU: [
+                    {
+                        mixerMessage: '/meters/1',
+                    },
+                ],
+                [fxParamsList.GainTrim]: [
+                    {
+                        mixerMessage: '/ch/{channel}/preamp/trim',
+                        minLabel: -18,
+                        maxLabel: 18,
+                        label: 'Gain Trim',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.CompThrs]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/thr',
+                        minLabel: -60,
+                        maxLabel: 0,
+                        label: 'Threshold',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.CompRatio]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/ratio',
+                        minLabel: 1,
+                        maxLabel: 10,
+                        label: 'Ratio',
+                        valueLabel: ' :1',
+                    },
+                ],
+                [fxParamsList.CompAttack]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/attack',
+                        minLabel: 0,
+                        maxLabel: 120,
+                        label: 'Attack',
+                        valueLabel: ' ms',
+                    },
+                ],
+                [fxParamsList.CompHold]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/hold',
+                        minLabel: 0,
+                        maxLabel: 2000,
+                        label: 'Hold',
+                        valueLabel: ' ms',
+                    },
+                ],
+                [fxParamsList.CompKnee]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/knee',
+                        minLabel: 0,
+                        maxLabel: 5,
+                        label: 'Knee',
+                        valueLabel: ' ',
+                    },
+                ],
+                [fxParamsList.CompMakeUp]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/mgain',
+                        minLabel: 0,
+                        maxLabel: 24,
+                        label: 'MakeUp',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.CompRelease]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/release',
+                        minLabel: 5,
+                        maxLabel: 4000,
+                        label: 'Release',
+                        valueLabel: ' ms',
+                    },
+                ],
+                [fxParamsList.DelayTime]: [
+                    {
+                        mixerMessage: '/ch/{channel}/delay/time',
+                        minLabel: 0,
+                        maxLabel: 500,
+                        label: 'Time',
+                        valueLabel: ' ms',
+                    },
+                ],
+                [fxParamsList.EqGain01]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/1/g',
+                        minLabel: -15,
+                        maxLabel: 15,
+                        label: 'Low',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.EqGain02]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/2/g',
+                        minLabel: -15,
+                        maxLabel: 15,
+                        label: 'LoMid',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.EqGain03]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/3/g',
+                        minLabel: -15,
+                        maxLabel: 15,
+                        label: 'HiMid',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.EqGain04]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/4/g',
+                        minLabel: -15,
+                        maxLabel: 15,
+                        label: 'High',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.EqFreq01]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/1/f',
+                        minLabel: 20,
+                        maxLabel: 20000,
+                        label: 'Low Freq',
+                        valueLabel: ' Freq',
+                    },
+                ],
+                [fxParamsList.EqFreq02]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/2/f',
+                        minLabel: 20,
+                        maxLabel: 20000,
+                        label: 'LoMid freq',
+                        valueLabel: ' Freq',
+                    },
+                ],
+                [fxParamsList.EqFreq03]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/3/f',
+                        minLabel: 20,
+                        maxLabel: 20000,
+                        label: 'HiMid freq',
+                        valueLabel: ' Freq',
+                    },
+                ],
+                [fxParamsList.EqFreq04]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/4/f',
+                        minLabel: 20,
+                        maxLabel: 20000,
+                        label: 'High freq',
+                        valueLabel: ' Freq',
+                    },
+                ],
+                [fxParamsList.EqQ01]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/1/q',
+                        minLabel: 10,
+                        maxLabel: 0.3,
+                        label: 'Low Q',
+                        valueLabel: ' Q',
+                    },
+                ],
+                [fxParamsList.EqQ02]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/2/q',
+                        minLabel: 10,
+                        maxLabel: 0.3,
+                        label: 'LoMid Q',
+                        valueLabel: ' Q',
+                    },
+                ],
+                [fxParamsList.EqQ03]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/3/q',
+                        minLabel: 10,
+                        maxLabel: 0.3,
+                        label: 'HiMid Q',
+                        valueLabel: ' Q',
+                    },
+                ],
+                [fxParamsList.EqQ04]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/4/q',
+                        minLabel: 10,
+                        maxLabel: 0.3,
+                        label: 'High Q',
+                        valueLabel: ' Q',
+                    },
+                ],
+                AUX_LEVEL: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/{argument}/level',
+                    },
+                ],
+                CHANNEL_MUTE_ON: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/on',
+                    },
+                ],
+            },
+            toMixer: {
+                CHANNEL_OUT_GAIN: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/fader',
+                    },
+                ],
+                [fxParamsList.GainTrim]: [
+                    {
+                        mixerMessage: '/ch/{channel}/preamp/trim',
+                        minLabel: -18,
+                        maxLabel: 18,
+                        label: 'Gain Trim',
+                        valueLabel: ' dB',
+                    },
+                ],
+                [fxParamsList.CompThrs]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/thr',
+                    },
+                ],
+                [fxParamsList.CompRatio]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/ratio',
+                    },
+                ],
+                [fxParamsList.CompAttack]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/attack',
+                    },
+                ],
+                [fxParamsList.CompHold]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/hold',
+                    },
+                ],
+                [fxParamsList.CompKnee]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/knee',
+                    },
+                ],
+                [fxParamsList.CompMakeUp]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/mgain',
+                    },
+                ],
+                [fxParamsList.CompRelease]: [
+                    {
+                        mixerMessage: '/ch/{channel}/dyn/release',
+                    },
+                ],
+                [fxParamsList.DelayTime]: [
+                    {
+                        mixerMessage: '/ch/{channel}/delay/time',
+                    },
+                ],
+                [fxParamsList.EqGain01]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/1/g',
+                    },
+                ],
+                [fxParamsList.EqGain02]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/2/g',
+                    },
+                ],
+                [fxParamsList.EqGain03]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/3/g',
+                    },
+                ],
+                [fxParamsList.EqGain04]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/4/g',
+                    },
+                ],
+                [fxParamsList.EqFreq01]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/1/f',
+                    },
+                ],
+                [fxParamsList.EqFreq02]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/2/f',
+                    },
+                ],
+                [fxParamsList.EqFreq03]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/3/f',
+                    },
+                ],
+                [fxParamsList.EqFreq04]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/4/f',
+                    },
+                ],
+                [fxParamsList.EqQ01]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/1/q',
+                    },
+                ],
+                [fxParamsList.EqQ02]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/2/q',
+                    },
+                ],
+                [fxParamsList.EqQ03]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/3/q',
+                    },
+                ],
+                [fxParamsList.EqQ04]: [
+                    {
+                        mixerMessage: '/ch/{channel}/eq/4/q',
+                    },
+                ],
+                AUX_LEVEL: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/{argument}/level',
+                    },
+                ],
+                CHANNEL_MUTE_ON: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/on',
+                        value: 0,
+                        type: 'f',
+                    },
+                ],
+                CHANNEL_MUTE_OFF: [
+                    {
+                        mixerMessage: '/ch/{channel}/mix/on',
+                        value: 1,
+                        type: 'f',
+                    },
+                ],
+            },
+        },
+    ],
+    fader: {
+        min: 0,
+        max: 1,
+        zero: 0.75,
+        step: 0.01,
+    },
+    meter: {
+        min: 0,
+        max: 1,
+        zero: 0.75,
+        test: 0.6,
+    },
+}

--- a/server/utils/MixerConnection.ts
+++ b/server/utils/MixerConnection.ts
@@ -10,6 +10,7 @@ import {
     fxParamsList,
 } from '../constants/MixerProtocolInterface'
 import { OscMixerConnection } from './mixerConnections/OscMixerConnection'
+import { VMixMixerConnection } from './mixerConnections/VMixMixerConnection'
 import { MidiMixerConnection } from './mixerConnections/MidiMixerConnection'
 import { QlClMixerConnection } from './mixerConnections/YamahaQlClConnection'
 import { SSLMixerConnection } from './mixerConnections/SSLMixerConnection'
@@ -91,6 +92,11 @@ export class MixerGenericConnection {
                 )
             } else if (this.mixerProtocol[index].protocol === 'SSL') {
                 this.mixerConnection[index] = new SSLMixerConnection(
+                    this.mixerProtocol[index] as IMixerProtocol,
+                    index
+                )
+            } else if (this.mixerProtocol[index].protocol === 'VMIX') {
+                this.mixerConnection[index] = new VMixMixerConnection(
                     this.mixerProtocol[index] as IMixerProtocol,
                     index
                 )

--- a/server/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/utils/mixerConnections/VMixMixerConnection.ts
@@ -322,6 +322,8 @@ export class VMixMixerConnection {
     }
 
     initialCommands() {
+        this.vmixConnection.send('XML')
+        this.vmixConnection.send({ Function: 'SUBSCRIBE TALLY' })
         return
         // To prevent network overload, timers will delay the requests.
         this.mixerProtocol.initializeCommands?.forEach(
@@ -449,15 +451,26 @@ export class VMixMixerConnection {
     }
 
     sendOutMessage(
-        oscMessage: string,
+        vMixMessage: string,
         channel: number,
         value: string | number,
         type: string
     ) {
-        let channelString = this.mixerProtocol.leadingZeros
+        if (typeof value === 'number') {
+            this.vmixConnection.send({
+                Function: `SetVolume&Input=1&Value=${value * 100}`,
+            })
+        } else {
+            this.vmixConnection.send({
+                Function: `SetVolume&Input=1&Value=${parseFloat(value) * 100}`,
+            })
+        }
+        this.vmixConnection.send({ Function: `SetBalance&Input=1&Value=-1` })
+
+        /*let channelString = this.mixerProtocol.leadingZeros
             ? ('0' + channel).slice(-2)
             : channel.toString()
-        let message = oscMessage.replace('{channel}', channelString)
+        let message = vMixMessage.replace('{channel}', channelString)
         if (message != 'none') {
             logger.verbose('Sending OSC command :' + message, {})
             this.vmixConnection.send({
@@ -469,7 +482,7 @@ export class VMixMixerConnection {
                     },
                 ],
             })
-        }
+        }*/
     }
 
     sendOutRequest(oscMessage: string, channel: number) {

--- a/server/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/utils/mixerConnections/VMixMixerConnection.ts
@@ -1,0 +1,695 @@
+//Node Modules:
+import { store, state } from '../../reducers/store'
+import { remoteConnections } from '../../mainClasses'
+import { ConnectionTCP } from 'node-vmix'
+
+//Utils:
+import {
+    fxParamsList,
+    IMixerProtocol,
+} from '../../constants/MixerProtocolInterface'
+import {
+    storeSetAuxLevel,
+    storeSetOutputLevel,
+} from '../../reducers/channelActions'
+import {
+    storeFaderLevel,
+    storeFaderLabel,
+    storeFaderFx,
+    storeTogglePgm,
+    storeSetMute,
+} from '../../reducers/faderActions'
+import { storeSetMixerOnline } from '../../reducers/settingsActions'
+import { logger } from '../logger'
+import { sendVuLevel, VuType } from '../vuServer'
+
+export class VMixMixerConnection {
+    mixerProtocol: IMixerProtocol
+    mixerIndex: number
+    cmdChannelIndex: number
+    vmixConnection: any
+    mixerOnlineTimer: any
+
+    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+        this.sendOutMessage = this.sendOutMessage.bind(this)
+        this.pingMixerCommand = this.pingMixerCommand.bind(this)
+
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
+
+        this.mixerProtocol = mixerProtocol
+        this.mixerIndex = mixerIndex
+        //If default store has been recreated multiple mixers are not created
+        if (!state.channels[0].chMixerConnection[this.mixerIndex]) {
+            state.channels[0].chMixerConnection[this.mixerIndex] = {
+                channel: [],
+            }
+        }
+
+        this.cmdChannelIndex = this.mixerProtocol.channelTypes[0].fromMixer.CHANNEL_OUT_GAIN[0].mixerMessage
+            .split('/')
+            .findIndex((ch) => ch === '{channel}')
+
+        this.vmixConnection = new ConnectionTCP(
+            state.settings[0].mixers[this.mixerIndex].deviceIp,
+            {
+                port: parseInt(
+                    state.settings[0].mixers[this.mixerIndex].devicePort + ''
+                ),
+            }
+        )
+        this.setupMixerConnection()
+    }
+
+    mixerOnline(onLineState: boolean) {
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, onLineState))
+        global.mainThreadHandler.updateMixerOnline(this.mixerIndex, onLineState)
+    }
+
+    setupMixerConnection() {
+        this.vmixConnection._socket
+            .on('connect', () => {
+                logger.info('Receiving state of desk', {})
+                this.initialCommands()
+
+                this.mixerOnline(true)
+                global.mainThreadHandler.updateFullClientStore()
+            })
+            .on('data', (message: any) => {
+                clearTimeout(this.mixerOnlineTimer)
+                if (!state.settings[0].mixers[this.mixerIndex].mixerOnline) {
+                    this.mixerOnline(true)
+                }
+                logger.verbose('Received OSC message: ' + message.address, {})
+
+                if (
+                    this.checkOscCommand(
+                        message.address,
+                        this.mixerProtocol.channelTypes[0].fromMixer
+                            .CHANNEL_VU?.[0].mixerMessage
+                    )
+                ) {
+                    let ch = message.address.split('/')[this.cmdChannelIndex]
+                    sendVuLevel(
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader,
+                        VuType.Channel,
+                        0,
+                        message.args[0]
+                    )
+                } else if (
+                    this.checkOscCommand(
+                        message.address,
+                        this.mixerProtocol.channelTypes[0].fromMixer
+                            .CHANNEL_VU_REDUCTION?.[0].mixerMessage
+                    )
+                ) {
+                    let ch = message.address.split('/')[this.cmdChannelIndex]
+                    sendVuLevel(
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader,
+                        VuType.Reduction,
+                        0,
+                        message.args[0]
+                    )
+                } else if (
+                    this.checkOscCommand(
+                        message.address,
+                        this.mixerProtocol.channelTypes[0].fromMixer
+                            .CHANNEL_OUT_GAIN?.[0].mixerMessage
+                    )
+                ) {
+                    let ch = message.address.split('/')[this.cmdChannelIndex]
+                    let assignedFaderIndex =
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader
+
+                    if (
+                        assignedFaderIndex >= 0 &&
+                        !state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].fadeActive
+                    ) {
+                        if (
+                            message.args[0] > this.mixerProtocol.fader.min ||
+                            message.args[0] >
+                                state.settings[0].autoResetLevel / 100
+                        ) {
+                            store.dispatch(
+                                storeFaderLevel(
+                                    assignedFaderIndex,
+                                    message.args[0]
+                                )
+                            )
+                            state.channels[0].chMixerConnection[
+                                this.mixerIndex
+                            ].channel.forEach((item, index) => {
+                                if (item.assignedFader === assignedFaderIndex) {
+                                    store.dispatch(
+                                        storeSetOutputLevel(
+                                            this.mixerIndex,
+                                            index,
+                                            message.args[0]
+                                        )
+                                    )
+                                }
+                            })
+                            if (
+                                !state.faders[0].fader[assignedFaderIndex].pgmOn
+                            ) {
+                                if (
+                                    message.args[0] >
+                                        this.mixerProtocol.fader.min ||
+                                    0
+                                ) {
+                                    store.dispatch(
+                                        storeTogglePgm(assignedFaderIndex)
+                                    )
+                                }
+                            }
+                        } else if (
+                            state.faders[0].fader[assignedFaderIndex].pgmOn ||
+                            state.faders[0].fader[assignedFaderIndex].voOn
+                        ) {
+                            store.dispatch(
+                                storeFaderLevel(
+                                    assignedFaderIndex,
+                                    message.args[0]
+                                )
+                            )
+                            state.channels[0].chMixerConnection[
+                                this.mixerIndex
+                            ].channel.forEach((item, index) => {
+                                if (item.assignedFader === assignedFaderIndex) {
+                                    store.dispatch(
+                                        storeSetOutputLevel(
+                                            this.mixerIndex,
+                                            index,
+                                            message.args[0]
+                                        )
+                                    )
+                                }
+                            })
+                        }
+                        global.mainThreadHandler.updatePartialStore(
+                            assignedFaderIndex
+                        )
+
+                        if (remoteConnections) {
+                            remoteConnections.updateRemoteFaderState(
+                                assignedFaderIndex,
+                                message.args[0]
+                            )
+                        }
+                    }
+                } else if (
+                    this.checkOscCommand(
+                        message.address,
+                        this.mixerProtocol.channelTypes?.[0].fromMixer
+                            .AUX_LEVEL?.[0].mixerMessage
+                    )
+                ) {
+                    let commandArray: string[] = this.mixerProtocol.channelTypes[0].fromMixer.AUX_LEVEL[0].mixerMessage.split(
+                        '/'
+                    )
+                    let messageArray: string[] = message.address.split('/')
+                    let ch = 0
+                    let auxIndex = 0
+
+                    commandArray.forEach(
+                        (commandPart: string, index: number) => {
+                            if (commandPart === '{channel}') {
+                                ch = parseFloat(messageArray[index])
+                            } else if (commandPart === '{argument}') {
+                                auxIndex = parseFloat(messageArray[index]) - 1
+                            }
+                        }
+                    )
+                    if (
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].auxLevel[auxIndex] > -1
+                    ) {
+                        logger.verbose(
+                            'Aux Message Channel : ' +
+                                ch +
+                                '  Aux Index :' +
+                                auxIndex +
+                                ' Level : ' +
+                                message.args[0]
+                        )
+                        store.dispatch(
+                            storeSetAuxLevel(
+                                this.mixerIndex,
+                                ch - 1,
+                                auxIndex,
+                                message.args[0]
+                            )
+                        )
+                        global.mainThreadHandler.updateFullClientStore()
+                        if (remoteConnections) {
+                            remoteConnections.updateRemoteAuxPanels()
+                        }
+                    }
+                } else if (
+                    this.checkOscCommand(
+                        message.address,
+                        this.mixerProtocol.channelTypes[0].fromMixer
+                            .CHANNEL_NAME?.[0].mixerMessage
+                    )
+                ) {
+                    let ch = message.address.split('/')[this.cmdChannelIndex]
+                    store.dispatch(
+                        storeFaderLabel(
+                            state.channels[0].chMixerConnection[this.mixerIndex]
+                                .channel[ch - 1].assignedFader,
+                            message.args[0]
+                        )
+                    )
+                    global.mainThreadHandler.updatePartialStore(
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader
+                    )
+                } else if (
+                    this.checkOscCommand(
+                        message.address,
+                        this.mixerProtocol.channelTypes[0].fromMixer
+                            .CHANNEL_MUTE_ON?.[0].mixerMessage
+                    )
+                ) {
+                    let ch = message.address.split('/')[this.cmdChannelIndex]
+                    store.dispatch(
+                        storeSetMute(
+                            state.channels[0].chMixerConnection[this.mixerIndex]
+                                .channel[ch - 1].assignedFader,
+                            message.args[0] === 0
+                        )
+                    )
+                    global.mainThreadHandler.updatePartialStore(
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader
+                    )
+                } else {
+                    this.checkFxCommands(message)
+                    logger.verbose(
+                        'Unknown OSC message: ' + message.address,
+                        {}
+                    )
+                }
+            })
+            .on('error', (error: any) => {
+                global.mainThreadHandler.updateFullClientStore()
+                logger.error('Error : ' + String(error), {})
+            })
+            .on('disconnect', () => {
+                this.mixerOnline(false)
+                logger.info('Lost OSC connection', {})
+            })
+
+        logger.info(
+            `OSC listening on port ` +
+                String(state.settings[0].mixers[this.mixerIndex].localOscPort),
+            {}
+        )
+
+        //Ping OSC mixer if mixerProtocol needs it.
+        if (this.mixerProtocol.pingTime > 0) {
+            let oscTimer = setInterval(() => {
+                this.pingMixerCommand()
+            }, this.mixerProtocol.pingTime)
+        }
+    }
+
+    initialCommands() {
+        // To prevent network overload, timers will delay the requests.
+        this.mixerProtocol.initializeCommands?.forEach(
+            (item, itemIndex: number) => {
+                setTimeout(() => {
+                    if (item.mixerMessage.includes('{channel}')) {
+                        if (item.type !== undefined && item.type === 'aux') {
+                            state.channels[0].chMixerConnection[
+                                this.mixerIndex
+                            ].channel.forEach((channel: any) => {
+                                channel.auxLevel.forEach(
+                                    (auxLevel: any, auxIndex: number) => {
+                                        if (channel.assignedFader >= 0) {
+                                            if (
+                                                state.faders[0].fader[
+                                                    channel.assignedFader
+                                                ]
+                                            ) {
+                                                setTimeout(() => {
+                                                    this.sendOutRequestAux(
+                                                        item.mixerMessage,
+                                                        auxIndex + 1,
+                                                        state.faders[0].fader[
+                                                            channel
+                                                                .assignedFader
+                                                        ].monitor
+                                                    )
+                                                }, state.faders[0].fader[channel.assignedFader].monitor * 10 + auxIndex * 100)
+                                            }
+                                        }
+                                    }
+                                )
+                            })
+                        } else {
+                            state.channels[0].chMixerConnection[
+                                this.mixerIndex
+                            ].channel.forEach((channel: any, index: any) => {
+                                this.sendOutRequest(
+                                    item.mixerMessage,
+                                    index + 1
+                                )
+                            })
+                        }
+                    } else {
+                        let value = item.value || 0
+                        let type = item.type || 'i'
+                        this.sendOutMessage(item.mixerMessage, 1, value, type)
+                    }
+                }, itemIndex * 100)
+            }
+        )
+    }
+
+    pingMixerCommand() {
+        //Ping OSC mixer if mixerProtocol needs it.
+        this.mixerProtocol.pingCommand.map((command) => {
+            let value = command.value || 0
+            let type = command.type || 'i'
+            this.sendOutMessage(command.mixerMessage, 0, value, type)
+        })
+        global.mainThreadHandler.updateFullClientStore()
+        this.mixerOnlineTimer = setTimeout(() => {
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
+        }, this.mixerProtocol.pingTime)
+    }
+
+    checkFxCommands(message: any) {
+        Object.keys(fxParamsList).forEach((keyName: string) => {
+            if (!isNaN(parseFloat(keyName))) {
+                return
+            }
+
+            let fxKey = keyName as keyof typeof fxParamsList
+            if (
+                this.checkOscCommand(
+                    message.address,
+                    this.mixerProtocol.channelTypes[0].fromMixer[
+                        fxParamsList[fxKey]
+                    ][0].mixerMessage
+                )
+            ) {
+                let ch = message.address.split('/')[this.cmdChannelIndex]
+                store.dispatch(
+                    storeFaderFx(
+                        fxParamsList[fxKey],
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader,
+                        message.args[0]
+                    )
+                )
+                global.mainThreadHandler.updatePartialStore(
+                    state.channels[0].chMixerConnection[this.mixerIndex]
+                        .channel[ch - 1].assignedFader
+                )
+            }
+
+            console.log(fxKey)
+        })
+    }
+
+    checkOscCommand(message: string, command: string | undefined): boolean {
+        if (!command) return false
+        if (message === command) return true
+        let messageArray: string[] = message.split('/')
+        let commandArray: string[] = command.split('/')
+        let status: boolean = true
+        if (messageArray.length !== commandArray.length) {
+            return false
+        }
+        commandArray.forEach((commandPart: string, index: number) => {
+            if (commandPart === '{channel}') {
+                if (typeof parseFloat(messageArray[index]) !== 'number') {
+                    status = false
+                }
+            } else if (commandPart === '{argument}') {
+                if (typeof parseFloat(messageArray[index]) !== 'number') {
+                    status = false
+                }
+            } else if (commandPart !== messageArray[index]) {
+                status = false
+            }
+        })
+        return status
+    }
+
+    sendOutMessage(
+        oscMessage: string,
+        channel: number,
+        value: string | number,
+        type: string
+    ) {
+        let channelString = this.mixerProtocol.leadingZeros
+            ? ('0' + channel).slice(-2)
+            : channel.toString()
+        let message = oscMessage.replace('{channel}', channelString)
+        if (message != 'none') {
+            logger.verbose('Sending OSC command :' + message, {})
+            this.vmixConnection.send({
+                address: message,
+                args: [
+                    {
+                        type: type,
+                        value: value,
+                    },
+                ],
+            })
+        }
+    }
+
+    sendOutRequest(oscMessage: string, channel: number) {
+        let channelString = this.mixerProtocol.leadingZeros
+            ? ('0' + channel).slice(-2)
+            : channel.toString()
+        let message = oscMessage.replace('{channel}', channelString)
+        if (message != 'none') {
+            this.vmixConnection.send({
+                address: message,
+            })
+        }
+    }
+
+    sendOutRequestAux(oscMessage: string, channel: number, auxSend: number) {
+        let channelString = this.mixerProtocol.leadingZeros
+            ? ('0' + channel).slice(-2)
+            : channel.toString()
+        let message = oscMessage.replace('{channel}', channelString)
+        let auxSendNumber = this.mixerProtocol.leadingZeros
+            ? ('0' + String(auxSend)).slice(-2)
+            : String(auxSend)
+        message = message.replace('{argument}', auxSendNumber)
+        logger.verbose('Initial Aux Message : ' + message)
+        if (message != 'none') {
+            this.vmixConnection.send({
+                address: message,
+            })
+        }
+    }
+
+    updateOutLevel(channelIndex: number) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channelTypeIndex =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex
+        this.sendOutMessage(
+            this.mixerProtocol.channelTypes[channelType].toMixer
+                .CHANNEL_OUT_GAIN[0].mixerMessage,
+            channelTypeIndex + 1,
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].outputLevel,
+            'f'
+        )
+    }
+
+    updatePflState(channelIndex: number) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channelTypeIndex =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex
+        if (state.faders[0].fader[channelIndex].pflOn === true) {
+            this.sendOutMessage(
+                this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
+                    .mixerMessage,
+                channelTypeIndex + 1,
+                this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
+                    .value,
+                this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
+                    .type
+            )
+        } else {
+            this.sendOutMessage(
+                this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF[0]
+                    .mixerMessage,
+                channelTypeIndex + 1,
+                this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF[0]
+                    .value,
+                this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF[0]
+                    .type
+            )
+        }
+    }
+
+    updateMuteState(channelIndex: number, muteOn: boolean) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channelTypeIndex =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex
+        if (muteOn === true) {
+            let mute = this.mixerProtocol.channelTypes[channelType].toMixer
+                .CHANNEL_MUTE_ON[0]
+            this.sendOutMessage(
+                mute.mixerMessage,
+                channelTypeIndex + 1,
+                mute.value,
+                mute.type
+            )
+        } else {
+            let mute = this.mixerProtocol.channelTypes[channelType].toMixer
+                .CHANNEL_MUTE_OFF[0]
+            this.sendOutMessage(
+                mute.mixerMessage,
+                channelTypeIndex + 1,
+                mute.value,
+                mute.type
+            )
+        }
+    }
+
+    updateNextAux(channelIndex: number, level: number) {
+        this.updateAuxLevel(
+            channelIndex,
+            state.settings[0].mixers[this.mixerIndex].nextSendAux - 1,
+            level
+        )
+    }
+
+    updateInputGain(channelIndex: number, level: number) {
+        return true
+    }
+    updateInputSelector(channelIndex: number, inputSelected: number) {
+        return true
+    }
+
+    updateFx(fxParam: fxParamsList, channelIndex: number, level: number) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channelTypeIndex =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex
+        let fx = this.mixerProtocol.channelTypes[channelType].toMixer[
+            fxParam
+        ][0]
+        this.sendOutMessage(fx.mixerMessage, channelTypeIndex + 1, level, 'f')
+    }
+
+    updateAuxLevel(channelIndex: number, auxSendIndex: number, level: number) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channel =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex + 1
+        let auxSendCmd = this.mixerProtocol.channelTypes[channelType].toMixer
+            .AUX_LEVEL[0]
+        let auxSendNumber = this.mixerProtocol.leadingZeros
+            ? ('0' + String(auxSendIndex + 1)).slice(-2)
+            : String(auxSendIndex + 1)
+        let message = auxSendCmd.mixerMessage.replace(
+            '{argument}',
+            auxSendNumber
+        )
+
+        this.sendOutMessage(message, channel, level, 'f')
+    }
+
+    updateFadeIOLevel(channelIndex: number, outputLevel: number) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channelTypeIndex =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex
+        this.sendOutMessage(
+            this.mixerProtocol.channelTypes[channelType].toMixer
+                .CHANNEL_OUT_GAIN[0].mixerMessage,
+            channelTypeIndex + 1,
+            String(outputLevel),
+            'f'
+        )
+    }
+
+    updateChannelName(channelIndex: number) {
+        let channelType =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelType
+        let channelTypeIndex =
+            state.channels[0].chMixerConnection[this.mixerIndex].channel[
+                channelIndex
+            ].channelTypeIndex
+        let channelName = state.faders[0].fader[channelIndex].label
+        this.sendOutMessage(
+            this.mixerProtocol.channelTypes[channelType].toMixer.CHANNEL_NAME[0]
+                .mixerMessage,
+            channelTypeIndex + 1,
+            channelName,
+            's'
+        )
+    }
+
+    loadMixerPreset(presetName: string) {
+        logger.info('Loading preset : ' + presetName)
+        if (this.mixerProtocol.presetFileExtension === 'X32') {
+            let data = JSON.parse(
+                '{}' // ''fs.readFileSync(path.resolve('storage', presetName))
+            )
+
+            this.vmixConnection.send({
+                address: this.mixerProtocol.loadPresetCommand[0].mixerMessage,
+                args: [
+                    {
+                        type: 's',
+                        value: 'scene',
+                    },
+                    {
+                        type: 'i',
+                        value: parseInt(data.sceneIndex),
+                    },
+                ],
+            })
+        }
+    }
+
+    injectCommand(command: string[]) {
+        return true
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,6 +1107,11 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
+
 after-all-results@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/after-all-results/-/after-all-results-2.0.0.tgz#6ac2fc202b500f88da8f4f5530cfa100f4c6a2d0"
@@ -4773,7 +4778,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7652,6 +7657,16 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+vmix-js-utils@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/vmix-js-utils/-/vmix-js-utils-4.0.6.tgz#8a93803b0a9191fdbcf7681b1d518f44bc325875"
+  integrity sha512-DcBtw6VmWlPGXZLmGwV2asssBJf7pLPmBuSTyLtAnwzc1wyhp8ZcUeTCUq6ka/Tv+EE+7xjAfElbQ1G6FgVl1A==
+  dependencies:
+    lodash "^4.17.21"
+    querystring "^0.2.1"
+    xmldom "^0.5.0"
+    xpath "^0.0.32"
+
 void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
@@ -7989,6 +8004,16 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
+
+xpath@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/xpath/-/xpath-0.0.32.tgz#1b73d3351af736e17ec078d6da4b8175405c48af"
+  integrity sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==
+
 xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -8081,6 +8106,11 @@ yargs@~1.2.6:
   integrity sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=
   dependencies:
     minimist "^0.1.0"
+
+yarn@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yeast@0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -3156,6 +3163,11 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3253,7 +3265,7 @@ get-pkg-repo@^1.0.0:
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
   integrity sha1-xztInAbYDMVTbCyFP54FIyBWly0=
   dependencies:
-    hosted-git-info "^2.8.9"
+    hosted-git-info "^2.1.4"
     meow "^3.3.0"
     normalize-package-data "^2.3.0"
     parse-github-repo-url "^1.3.0"
@@ -3493,9 +3505,9 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-
     lru-cache "^6.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.0:
   version "4.0.0"
@@ -5223,12 +5235,20 @@ node-releases@^1.1.70:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
+node-vmix@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/node-vmix/-/node-vmix-1.5.2.tgz#0da0e34cd0f318d70247e7d631b50e76d498f0ab"
+  integrity sha512-0V1MKpoa3vprx5igvpPnLHyvm0UY7spWEFjG/izn73zUp/JbaycT1NVfxNR9VT8rLlv5MmLJk9MZPyiYF2HARQ==
+  dependencies:
+    axios "^0.21.1"
+    querystring "^0.2.1"
+
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
   dependencies:
-    hosted-git-info "^2.8.9"
+    hosted-git-info "^2.1.4"
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
@@ -5277,7 +5297,7 @@ npm-package-arg@^4.2.0:
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-4.2.1.tgz#593303fdea85f7c422775f17f9eb7670f680e3ec"
   integrity sha1-WTMD/eqF98Qid18X+et2cPaA4+w=
   dependencies:
-    hosted-git-info "^2.8.9"
+    hosted-git-info "^2.1.5"
     semver "^5.1.0"
 
 npm-run-path@^2.0.0:
@@ -5894,6 +5914,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
 quick-lru@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Based on previous work done in the main repository.

Because the SOLO and VU meters in VMix are post fader I've had to make it so that the fader will be up even when the channel is turned off in Sisyfos, it feels a little counter intuitive but works OK