### PR TITLE
Feat: emit labels over automation connection

### DIFF
--- a/server/utils/AutomationConnection.ts
+++ b/server/utils/AutomationConnection.ts
@@ -23,6 +23,7 @@ import {
     storeFadeToBlack,
     storeClearPst,
 } from '../reducers/faderActions'
+import { getFaderLabel } from './labels'
 import { logger } from './logger'
 
 const AUTOMATION_OSC_PORT = 5255
@@ -196,18 +197,22 @@ export class AutomationConnection {
                     0,
                     JSON.stringify({
                         channel: state.faders[0].fader.map(
-                            ({
+                            (
+                                {
+                                    faderLevel,
+                                    pgmOn,
+                                    voOn,
+                                    pstOn,
+                                    showChannel,
+                                }: IFader,
+                                index
+                            ) => ({
                                 faderLevel,
                                 pgmOn,
                                 voOn,
                                 pstOn,
                                 showChannel,
-                            }: IFader) => ({
-                                faderLevel,
-                                pgmOn,
-                                voOn,
-                                pstOn,
-                                showChannel,
+                                label: getFaderLabel(index),
                             })
                         ),
                     }),

--- a/server/utils/labels.ts
+++ b/server/utils/labels.ts
@@ -1,0 +1,48 @@
+import { IStore } from '../reducers/indexReducer'
+import { state } from '../reducers/store'
+
+export function getChannelLabel(
+    state: IStore,
+    faderIndex: number
+): string | undefined {
+    return state.channels[0].chMixerConnection
+        .map((conn) =>
+            conn.channel.map((ch) => ({
+                assignedFader: ch.assignedFader,
+                label: ch.label,
+            }))
+        )
+        .reduce((a, b) => [...a, ...b], []) // flatten
+        .filter((ch) => ch.label && ch.label !== '')
+        .find((ch) => ch.assignedFader === faderIndex)?.label
+}
+
+export function getFaderLabel(faderIndex: number, defaultName = 'CH'): string {
+    const automationLabel =
+        state.faders[0].fader[faderIndex] &&
+        state.faders[0].fader[faderIndex].label !== ''
+            ? state.faders[0].fader[faderIndex].label
+            : undefined
+    const userLabel =
+        state.faders[0].fader[faderIndex] &&
+        state.faders[0].fader[faderIndex].userLabel !== ''
+            ? state.faders[0].fader[faderIndex].userLabel
+            : undefined
+    const channelLabel = getChannelLabel(state, faderIndex)
+
+    switch (state.settings[0].labelType) {
+        case 'automatic':
+            return (
+                userLabel ||
+                automationLabel ||
+                channelLabel ||
+                defaultName + ' ' + (faderIndex + 1)
+            )
+        case 'automation':
+            return automationLabel || defaultName + ' ' + (faderIndex + 1)
+        case 'user':
+            return userLabel || defaultName + ' ' + (faderIndex + 1)
+        case 'channel':
+            return channelLabel || defaultName + ' ' + (faderIndex + 1)
+    }
+}


### PR DESCRIPTION
When requesting a full state, Sisyfos will include the label currently shown to the user