### PR TITLE
fix: Midas - when loading a new preset, settings was not received

### DIFF
--- a/server/constants/mixerProtocols/midasMaster.ts
+++ b/server/constants/mixerProtocols/midasMaster.ts
@@ -158,6 +158,8 @@ export const MidasMaster: IMixerProtocol = {
                 [fxParamsList.CompRatio]: [
                     {
                         mixerMessage: '/ch/{channel}/dyn/ratio',
+                        min: 0,
+                        max: 11,
                         minLabel: 0,
                         maxLabel: 11,
                         label: 'Ratio',

--- a/server/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/utils/mixerConnections/OscMixerConnection.ts
@@ -452,6 +452,7 @@ export class OscMixerConnection {
             let fxMessage = this.mixerProtocol.channelTypes[0].fromMixer[
                 fxParamsList[fxKey]
             ][0]
+            let range: number = fxMessage.max - fxMessage.min || 1
             if (this.checkOscCommand(message.address, fxMessage.mixerMessage)) {
                 let ch = message.address.split('/')[this.cmdChannelIndex]
 
@@ -460,8 +461,7 @@ export class OscMixerConnection {
                         fxParamsList[fxKey],
                         state.channels[0].chMixerConnection[this.mixerIndex]
                             .channel[ch - 1].assignedFader,
-                        message.args[0] /
-                            (fxMessage.maxLabel - fxMessage.minLabel)
+                        message.args[0] / range
                     )
                 )
                 global.mainThreadHandler.updatePartialStore(
@@ -743,6 +743,9 @@ export class OscMixerConnection {
                     },
                 ],
             })
+            setTimeout(() => {
+                this.initialCommands()
+            }, 1000)
         }
     }
 


### PR DESCRIPTION
Fix: when loading a preset, new Midas values was not received 
Fix: mixLabel maxLabel should not be used for OSC conversion. Use min and max instead.