### PR TITLE
fix: Use version from bump-version instead of package.json in node-ci.prod

### DIFF
--- a/.github/version
+++ b/.github/version
@@ -1,1 +1,1 @@
-1.11.4-locally-modified
+1.11.5-locally-modified

--- a/.github/workflows/node-ci.prod.yml
+++ b/.github/workflows/node-ci.prod.yml
@@ -281,18 +281,11 @@ jobs:
           name: ${{ github.event.repository.name }}
           path: dist
 
-      - name: Get raw version
-        id: raw-version
-        uses: notiz-dev/github-action-json-property@release
-        with: 
-            path: 'package.json'
-            prop_path: 'version'
-
       - name: Extract version for tags
         id: version
         uses: ./.github/actions/extract-version
         with:
-          version: ${{ steps.raw-version.outputs.prop }}
+          version: ${{ needs.bump-version.outputs.version }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
Previous behaviour was that the docker hub tags were using the old version, which was read from package.json.
To counter this, the version gained from bumping the version is used instead.