### PR TITLE
Feat/better config update handling - (now into develop)

### DIFF
--- a/client/components/Settings.tsx
+++ b/client/components/Settings.tsx
@@ -10,7 +10,7 @@ import { ISettings } from '../../server/reducers/settingsReducer'
 import { Store } from 'redux'
 import { ChangeEvent } from 'react'
 import { SOCKET_SAVE_SETTINGS } from '../../server/constants/SOCKET_IO_DISPATCHERS'
-import { storeShowSettings } from '../../server/reducers/settingsActions'
+import { storeSetServerOnline, storeShowSettings } from '../../server/reducers/settingsActions'
 
 //Set style for Select dropdown component:
 const selectorColorStyles = {
@@ -169,7 +169,13 @@ class Settings extends React.PureComponent<IAppProps & Store, IState> {
         let settingsCopy = Object.assign({}, this.state.settings)
         settingsCopy.showSettings = false
         window.socketIoClient.emit(SOCKET_SAVE_SETTINGS, settingsCopy)
-        location.reload()
+        this.props.dispatch(storeShowSettings())
+        window.alert(
+            'restarting Sisyfos'
+        )
+        setTimeout(()=> {
+            location.reload()
+        }, 2000)
     }
 
     handleCancel = () => {
@@ -553,7 +559,7 @@ class Settings extends React.PureComponent<IAppProps & Store, IState> {
                         this.handleSave()
                     }}
                 >
-                    SAVE SETTINGS
+                    SAVE & RESTART
                 </button>
             </div>
         )

--- a/server/MainThreadHandler.ts
+++ b/server/MainThreadHandler.ts
@@ -213,6 +213,10 @@ export class MainThreadHandlers {
                 logger.data(payload).info('Save settings:')
                 saveSettings(payload)
                 this.updateFullClientStore()
+                /** Delay restart to ensure the async saveSettings is done before restarting*/
+                setTimeout(() => {
+                    process.exit(0)
+                }, 1000)
             })
             .on(IO.SOCKET_RESTART_SERVER, () => {
                 process.exit(0)

--- a/server/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/utils/mixerConnections/OscMixerConnection.ts
@@ -93,7 +93,6 @@ export class OscMixerConnection {
             })
             .on('message', (message: any) => {
                 clearTimeout(this.mixerOnlineTimer)
-                this.resetMixerTimeout()
                 if (!state.settings[0].mixers[this.mixerIndex].mixerOnline) {
                     logger.info(
                         `Audio Mixer number: ${this.mixerIndex + 1} is Online`
@@ -120,6 +119,7 @@ export class OscMixerConnection {
                             this.mixerIndex
                         ].mixerProtocol.includes('midas')
                     ) {
+                        this.resetMixerTimeout()
                         midasMeter(this.mixerIndex, message.args)
                     } else {
                         let ch = message.address.split('/')[


### PR DESCRIPTION
The save button in Settings are now changed to "SAVE & RESTART" and a popup alert ensure that the client knows Sisyfos is restarting. (And delays the reload so it's not reloading before the new config are used on the server)