### PR TITLE
fix: remove recalcAssignedChannels from hot path

### DIFF
--- a/server/MainThreadHandler.ts
+++ b/server/MainThreadHandler.ts
@@ -111,7 +111,6 @@ export class MainThreadHandlers {
     }
 
     updatePartialStore(faderIndex: number) {
-        this.recalcAssignedChannels()
         socketServer.emit(SOCKET_SET_STORE_FADER, {
             faderIndex: faderIndex,
             state: state.faders[0].fader[faderIndex],


### PR DESCRIPTION
The assigned channels are recalculated every time the automation system sends an update. This is unnecessary and since the recalculation is costly can hamper performance greatly. The calculation should only be done when a channel is reassigned to a different fader.