### PR TITLE
SIS-37/Removed min-height for mic-tally.

### DIFF
--- a/client/src/assets/css/MicTally.css
+++ b/client/src/assets/css/MicTally.css
@@ -15,7 +15,6 @@ body.v-mic-tally {
     list-style: none;
     align-items: stretch;
     flex-wrap: wrap;
-    min-height: 150px;
     padding: 0;
     margin: 0;
     opacity: 0;


### PR DESCRIPTION
By doing so, the component can fit in smaller areas like the Kommentator View in Sofie QBox.