### PR TITLE
Sis 36/new buffer deprecated

### DIFF
--- a/server/src/utils/mixerConnections/SSLMixerConnection.ts
+++ b/server/src/utils/mixerConnections/SSLMixerConnection.ts
@@ -32,9 +32,10 @@ export class SSLMixerConnection {
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
 
-        this.cmdChannelIndex = this.mixerProtocol.channelTypes[0].fromMixer.CHANNEL_OUT_GAIN[0].mixerMessage
-            .split('/')
-            .findIndex((ch) => ch === '{channel}')
+        this.cmdChannelIndex =
+            this.mixerProtocol.channelTypes[0].fromMixer.CHANNEL_OUT_GAIN[0].mixerMessage
+                .split('/')
+                .findIndex((ch) => ch === '{channel}')
 
         this.SSLConnection = new net.Socket()
         this.SSLConnection.connect(
@@ -186,20 +187,25 @@ export class SSLMixerConnection {
                                     )
                                     state.channels[0].chMixerConnection[
                                         this.mixerIndex
-                                    ].channel.forEach((item: { assignedFader: any }, index: number) => {
-                                        if (
-                                            item.assignedFader ===
-                                            assignedFaderIndex
-                                        ) {
-                                            store.dispatch(
-                                                storeSetOutputLevel(
-                                                    this.mixerIndex,
-                                                    index,
-                                                    value
+                                    ].channel.forEach(
+                                        (
+                                            item: { assignedFader: any },
+                                            index: number
+                                        ) => {
+                                            if (
+                                                item.assignedFader ===
+                                                assignedFaderIndex
+                                            ) {
+                                                store.dispatch(
+                                                    storeSetOutputLevel(
+                                                        this.mixerIndex,
+                                                        index,
+                                                        value
+                                                    )
                                                 )
-                                            )
+                                            }
                                         }
-                                    })
+                                    )
                                 }
                                 global.mainThreadHandler.updatePartialStore(
                                     assignedFaderIndex
@@ -373,7 +379,7 @@ export class SSLMixerConnection {
         )
         sslMessage = sslMessage + this.calculate_checksum8(sslMessage.slice(9))
         let a = sslMessage.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             a.map((val: string) => {
                 return parseInt(val, 16)
             })
@@ -398,7 +404,7 @@ export class SSLMixerConnection {
         sslMessage =
             sslMessage + ' ' + this.calculate_checksum8(sslMessage.slice(9))
         let a = sslMessage.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             a.map((val: string) => {
                 return parseInt(val, 16)
             })
@@ -413,7 +419,7 @@ export class SSLMixerConnection {
         sslMessage =
             sslMessage + ' ' + this.calculate_checksum8(sslMessage.slice(9))
         let a = sslMessage.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             a.map((val: string) => {
                 return parseInt(val, 16)
             })

--- a/server/src/utils/mixerConnections/StuderMixerConnection.ts
+++ b/server/src/utils/mixerConnections/StuderMixerConnection.ts
@@ -220,12 +220,14 @@ export class StuderMixerConnection {
             ].channelTypeIndex
 
         if (channel < 25) {
-            levelMessage = this.mixerProtocol.channelTypes[channelType].toMixer
-                .CHANNEL_OUT_GAIN[0].mixerMessage
+            levelMessage =
+                this.mixerProtocol.channelTypes[channelType].toMixer
+                    .CHANNEL_OUT_GAIN[0].mixerMessage
             channelVal = 160 + channelTypeIndex + 1
         } else {
-            levelMessage = this.mixerProtocol.channelTypes[channelType].toMixer
-                .CHANNEL_OUT_GAIN[1].mixerMessage
+            levelMessage =
+                this.mixerProtocol.channelTypes[channelType].toMixer
+                    .CHANNEL_OUT_GAIN[1].mixerMessage
             channelVal = channelTypeIndex + 1
         }
 
@@ -248,7 +250,7 @@ export class StuderMixerConnection {
         )
 
         let hexArray = levelMessage.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             hexArray.map((val: string) => {
                 return parseInt(val, 16)
             })

--- a/server/src/utils/mixerConnections/StuderVistaMixerConnection.ts
+++ b/server/src/utils/mixerConnections/StuderVistaMixerConnection.ts
@@ -222,15 +222,12 @@ export class StuderVistaMixerConnection {
 
     handleEmberAuxCommand(message: string) {
         // Extract Channel number, Aux and Type (mono-st-51)
-        let {
-            channelTypeIndex,
-            channelType,
-            auxIndex,
-        } = this.extractMessageIndex(
-            this.mixerProtocol.channelTypes[0].fromMixer.AUX_LEVEL[0]
-                .mixerMessage,
-            message
-        )
+        let { channelTypeIndex, channelType, auxIndex } =
+            this.extractMessageIndex(
+                this.mixerProtocol.channelTypes[0].fromMixer.AUX_LEVEL[0]
+                    .mixerMessage,
+                message
+            )
 
         // Extract value:
         let value = this.extractValue(message)
@@ -460,7 +457,7 @@ export class StuderVistaMixerConnection {
         )
 
         let hexArray = mixerMessage.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             hexArray.map((val: string) => {
                 return parseInt(val, 16)
             })
@@ -481,8 +478,9 @@ export class StuderVistaMixerConnection {
                 channel - 1
             ].channelTypeIndex
 
-        levelMessage = this.mixerProtocol.channelTypes[channelType].toMixer
-            .CHANNEL_OUT_GAIN[0].mixerMessage
+        levelMessage =
+            this.mixerProtocol.channelTypes[channelType].toMixer
+                .CHANNEL_OUT_GAIN[0].mixerMessage
         channelVal = 160 + channelTypeIndex + 1
 
         let channelByte = new Uint8Array([channelVal & 0x000000ff])
@@ -508,7 +506,7 @@ export class StuderVistaMixerConnection {
         )
 
         let hexArray = levelMessage.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             hexArray.map((val: string) => {
                 return parseInt(val, 16)
             })
@@ -559,16 +557,18 @@ export class StuderVistaMixerConnection {
                 channelIndex
             ].channelTypeIndex
         if (muteOn === true) {
-            let mute = this.mixerProtocol.channelTypes[channelType].toMixer
-                .CHANNEL_MUTE_ON[0]
+            let mute =
+                this.mixerProtocol.channelTypes[channelType].toMixer
+                    .CHANNEL_MUTE_ON[0]
             this.sendOutMessage(
                 mute.mixerMessage,
                 channelTypeIndex + 1,
                 mute.value
             )
         } else {
-            let mute = this.mixerProtocol.channelTypes[channelType].toMixer
-                .CHANNEL_MUTE_OFF[0]
+            let mute =
+                this.mixerProtocol.channelTypes[channelType].toMixer
+                    .CHANNEL_MUTE_OFF[0]
             this.sendOutMessage(
                 mute.mixerMessage,
                 channelTypeIndex + 1,
@@ -604,8 +604,8 @@ export class StuderVistaMixerConnection {
             state.channels[0].chMixerConnection[this.mixerIndex].channel[
                 channelIndex
             ].channelTypeIndex + 1
-        let auxSendCmd = this.mixerProtocol.channelTypes[channelType].toMixer
-            .AUX_LEVEL[0]
+        let auxSendCmd =
+            this.mixerProtocol.channelTypes[channelType].toMixer.AUX_LEVEL[0]
         let auxSendNumber = 160 + auxSendIndex + 1
 
         let auxByte = new Uint8Array([auxSendNumber & 0x000000ff])

--- a/server/src/utils/mixerConnections/YamahaQlClConnection.ts
+++ b/server/src/utils/mixerConnections/YamahaQlClConnection.ts
@@ -35,9 +35,10 @@ export class QlClMixerConnection {
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
 
-        this.cmdChannelIndex = this.mixerProtocol.channelTypes[0].fromMixer.CHANNEL_OUT_GAIN[0].mixerMessage
-            .split('/')
-            .findIndex((ch) => ch === '{channel}')
+        this.cmdChannelIndex =
+            this.mixerProtocol.channelTypes[0].fromMixer.CHANNEL_OUT_GAIN[0].mixerMessage
+                .split('/')
+                .findIndex((ch) => ch === '{channel}')
 
         this.midiConnection = new net.Socket()
         this.midiConnection.connect(
@@ -293,7 +294,7 @@ export class QlClMixerConnection {
             valueByte[0].toString(16) + ' ' + valueByte[1].toString(16)
         )
         let a = command.split(' ')
-        let buf = new Buffer(
+        let buf = Buffer.from(
             a.map((val: string) => {
                 return parseInt(val, 16)
             })


### PR DESCRIPTION
Changed `new Buffer(` to `Buffer.from(`.