### PR TITLE
fix(SOF-875): Lowered log level of a log call, reducing logs significantly.

### DIFF
--- a/server/src/utils/AutomationConnection.ts
+++ b/server/src/utils/AutomationConnection.ts
@@ -100,9 +100,7 @@ export class AutomationConnection {
                 global.mainThreadHandler.updatePartialStore(ch - 1)
             }
 
-            logger.info(
-                `RECIEVED AUTOMATION MESSAGE :${message.address}, ${message.args[0]}`
-            )
+            logger.data(message).debug(`RECIEVED AUTOMATION MESSAGE: ${message.address}`)
 
             // Set state of Sisyfos:
             if (check('CHANNEL_PGM_ON_OFF')) {

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -344,7 +344,7 @@ export class VMixMixerConnection {
                 )
             }
 
-            //            logger.trace(fxKey)
+            logger.trace(fxKey)
         })
     }
 


### PR DESCRIPTION
- Changed AutomationConnection.setupAutomationConnection() to use debug level log instead of info level.
	- Included message as data as part of log instead of only a snippet of the log, which was undefined
- Changed VMixMixerConnection.checkFxCommands to match how OscMixerConnection.checkFxCommands does the same log (i.e uncommented log statement)