### PR TITLE
Feat/reflect mixerchange to other mixer

### DIFF
--- a/server/src/MainThreadHandler.ts
+++ b/server/src/MainThreadHandler.ts
@@ -312,13 +312,13 @@ export class MainThreadHandlers {
             .on(IO.SOCKET_TOGGLE_PGM, (faderIndex: any) => {
                 mixerGenericConnection.checkForAutoResetThreshold(faderIndex)
                 store.dispatch(FADER_ACTIONS.storeTogglePgm(faderIndex))
-                mixerGenericConnection.updateOutLevel(faderIndex)
+                mixerGenericConnection.updateOutLevel(faderIndex, -1)
                 this.updatePartialStore(faderIndex)
             })
             .on(IO.SOCKET_TOGGLE_VO, (faderIndex: any) => {
                 mixerGenericConnection.checkForAutoResetThreshold(faderIndex)
                 store.dispatch(FADER_ACTIONS.storeToggleVo(faderIndex))
-                mixerGenericConnection.updateOutLevel(faderIndex)
+                mixerGenericConnection.updateOutLevel(faderIndex, -1)
                 this.updatePartialStore(faderIndex)
             })
             .on(IO.SOCKET_TOGGLE_SLOW_FADE, (faderIndex: any) => {

--- a/server/src/utils/AutomationConnection.ts
+++ b/server/src/utils/AutomationConnection.ts
@@ -125,7 +125,7 @@ export class AutomationConnection {
                             parseFloat(message.args[1])
                         )
                     } else {
-                        mixerGenericConnection.updateOutLevel(ch - 1)
+                        mixerGenericConnection.updateOutLevel(ch - 1, -1)
                     }
                 })
             } else if (check('CHANNEL_PST_ON_OFF')) {
@@ -147,7 +147,7 @@ export class AutomationConnection {
             } else if (check('CHANNEL_FADER_LEVEL')) {
                 wrapChannelCommand((ch: any) => {
                     store.dispatch(storeFaderLevel(ch - 1, message.args[0]))
-                    mixerGenericConnection.updateOutLevel(ch - 1)
+                    mixerGenericConnection.updateOutLevel(ch - 1, -1)
                     global.mainThreadHandler.updatePartialStore(ch - 1)
                 })
             } else if (check('INJECT_COMMAND')) {

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -20,7 +20,10 @@ import { LawoRubyMixerConnection } from './mixerConnections/LawoRubyConnection'
 import { StuderMixerConnection } from './mixerConnections/StuderMixerConnection'
 import { StuderVistaMixerConnection } from './mixerConnections/StuderVistaMixerConnection'
 import { CasparCGConnection } from './mixerConnections/CasparCGConnection'
-import { IChannel, IchMixerConnection } from '../../../shared/src/reducers/channelsReducer'
+import {
+    IChannel,
+    IchMixerConnection,
+} from '../../../shared/src/reducers/channelsReducer'
 import {
     storeFadeActive,
     storeSetOutputLevel,
@@ -160,18 +163,22 @@ export class MixerGenericConnection {
 
     updateFadeToBlack = () => {
         state.faders[0].fader.forEach((channel: any, index: number) => {
-            this.updateOutLevel(index)
+            this.updateOutLevel(index, -1)
         })
     }
 
-    updateOutLevels = () => {
+    updateOutLevels = (allMixersButThis: number = -1) => {
         state.faders[0].fader.forEach((channel: any, index: number) => {
-            this.updateOutLevel(index)
+            this.updateOutLevel(index, -1)
             this.updateNextAux(index)
         })
     }
 
-    updateOutLevel = (faderIndex: number, fadeTime: number = -1) => {
+    updateOutLevel = (
+        faderIndex: number,
+        fadeTime: number,
+        allMixersButThis: number = -1
+    ) => {
         if (fadeTime === -1) {
             if (state.faders[0].fader[faderIndex].voOn) {
                 fadeTime = state.settings[0].voFadeTime
@@ -190,13 +197,19 @@ export class MixerGenericConnection {
 
         state.channels[0].chMixerConnection.forEach(
             (chMixerConnection: IchMixerConnection, mixerIndex: number) => {
-                chMixerConnection.channel.forEach(
-                    (channel: IChannel, channelIndex: number) => {
-                        if (faderIndex === channel.assignedFader) {
-                            this.fadeInOut(mixerIndex, channelIndex, fadeTime)
+                if (mixerIndex !== allMixersButThis) {
+                    chMixerConnection.channel.forEach(
+                        (channel: IChannel, channelIndex: number) => {
+                            if (faderIndex === channel.assignedFader) {
+                                this.fadeInOut(
+                                    mixerIndex,
+                                    channelIndex,
+                                    fadeTime
+                                )
+                            }
                         }
-                    }
-                )
+                    )
+                }
             }
         )
 
@@ -415,7 +428,7 @@ export class MixerGenericConnection {
         const outputLevel =
             state.channels[0].chMixerConnection[mixerIndex].channel[
                 channelIndex
-                ].outputLevel
+            ].outputLevel
         let targetVal = state.faders[0].fader[faderIndex].faderLevel
 
         if (state.faders[0].fader[faderIndex].voOn) {
@@ -425,22 +438,54 @@ export class MixerGenericConnection {
         this.fade(fadeTime, mixerIndex, channelIndex, outputLevel, targetVal)
     }
 
-    fade(fadeTime: number, mixerIndex: number, channelIndex: number, startLevel: number, endLevel: number) {
+    fade(
+        fadeTime: number,
+        mixerIndex: number,
+        channelIndex: number,
+        startLevel: number,
+        endLevel: number
+    ) {
         const startTimeAsMs = Date.now()
-        const updateInterval: number =  Math.floor(1000 / this.mixerProtocol[mixerIndex].MAX_UPDATES_PER_SECOND)
+        const updateInterval: number = Math.floor(
+            1000 / this.mixerProtocol[mixerIndex].MAX_UPDATES_PER_SECOND
+        )
 
         this.clearTimer(mixerIndex, channelIndex)
 
-        this.mixerTimers[mixerIndex].chTimer[channelIndex] = setInterval(() => this.updateOutputLevel(startTimeAsMs, fadeTime, mixerIndex, channelIndex, startLevel, endLevel), updateInterval)
-        this.updateOutputLevel(startTimeAsMs, fadeTime, mixerIndex, channelIndex, startLevel, endLevel)
+        this.mixerTimers[mixerIndex].chTimer[channelIndex] = setInterval(
+            () =>
+                this.updateOutputLevel(
+                    startTimeAsMs,
+                    fadeTime,
+                    mixerIndex,
+                    channelIndex,
+                    startLevel,
+                    endLevel
+                ),
+            updateInterval
+        )
+        this.updateOutputLevel(
+            startTimeAsMs,
+            fadeTime,
+            mixerIndex,
+            channelIndex,
+            startLevel,
+            endLevel
+        )
     }
 
-    private updateOutputLevel(startTimeAsMs: number, fadeTime: number, mixerIndex: number, channelIndex: number, startLevel: number, endLevel: number  ) {
+    private updateOutputLevel(
+        startTimeAsMs: number,
+        fadeTime: number,
+        mixerIndex: number,
+        channelIndex: number,
+        startLevel: number,
+        endLevel: number
+    ) {
         const currentTimeMS = Date.now()
         const elapsedTimeMS = currentTimeMS - startTimeAsMs
 
         if (elapsedTimeMS >= fadeTime) {
-
             this.mixerConnection[mixerIndex].updateFadeIOLevel(
                 channelIndex,
                 endLevel
@@ -453,7 +498,10 @@ export class MixerGenericConnection {
             return true
         }
 
-        const currentOutputLevel = startLevel + ((endLevel - startLevel) * Math.max(0, Math.min(1, elapsedTimeMS / fadeTime)))
+        const currentOutputLevel =
+            startLevel +
+            (endLevel - startLevel) *
+                Math.max(0, Math.min(1, elapsedTimeMS / fadeTime))
 
         this.mixerConnection[mixerIndex].updateFadeIOLevel(
             channelIndex,
@@ -469,7 +517,7 @@ export class MixerGenericConnection {
         const outputLevel =
             state.channels[0].chMixerConnection[mixerIndex].channel[
                 channelIndex
-                ].outputLevel
+            ].outputLevel
 
         this.fade(fadeTime, mixerIndex, channelIndex, outputLevel, 0)
     }

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -167,7 +167,7 @@ export class MixerGenericConnection {
         })
     }
 
-    updateOutLevels = (allMixersButThis: number = -1) => {
+    updateOutLevels = () => {
         state.faders[0].fader.forEach((channel: any, index: number) => {
             this.updateOutLevel(index, -1)
             this.updateNextAux(index)
@@ -177,7 +177,7 @@ export class MixerGenericConnection {
     updateOutLevel = (
         faderIndex: number,
         fadeTime: number,
-        allMixersButThis: number = -1
+        mixerIndexToSkip: number = -1
     ) => {
         if (fadeTime === -1) {
             if (state.faders[0].fader[faderIndex].voOn) {
@@ -197,7 +197,7 @@ export class MixerGenericConnection {
 
         state.channels[0].chMixerConnection.forEach(
             (chMixerConnection: IchMixerConnection, mixerIndex: number) => {
-                if (mixerIndex !== allMixersButThis) {
+                if (mixerIndex !== mixerIndexToSkip) {
                     chMixerConnection.channel.forEach(
                         (channel: IChannel, channelIndex: number) => {
                             if (faderIndex === channel.assignedFader) {
@@ -261,10 +261,10 @@ export class MixerGenericConnection {
         this.mixerConnection[0].updatePflState(channelIndex)
     }
 
-    updateMuteState = (faderIndex: number, allMixersButThis: number = -1) => {
+    updateMuteState = (faderIndex: number, mixerIndexToSkip: number = -1) => {
         state.channels[0].chMixerConnection.forEach(
             (chMixerConnection: IchMixerConnection, mixerIndex: number) => {
-                if (mixerIndex !== allMixersButThis) {
+                if (mixerIndex !== mixerIndexToSkip) {
                     chMixerConnection.channel.forEach(
                         (channel: IChannel, channelIndex: number) => {
                             if (faderIndex === channel.assignedFader) {

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -261,19 +261,23 @@ export class MixerGenericConnection {
         this.mixerConnection[0].updatePflState(channelIndex)
     }
 
-    updateMuteState = (faderIndex: number) => {
+    updateMuteState = (faderIndex: number, allMixersButThis: number = -1) => {
         state.channels[0].chMixerConnection.forEach(
             (chMixerConnection: IchMixerConnection, mixerIndex: number) => {
-                chMixerConnection.channel.forEach(
-                    (channel: IChannel, channelIndex: number) => {
-                        if (faderIndex === channel.assignedFader) {
-                            this.mixerConnection[mixerIndex].updateMuteState(
-                                channelIndex,
-                                state.faders[0].fader[faderIndex].muteOn
-                            )
+                if (mixerIndex !== allMixersButThis) {
+                    chMixerConnection.channel.forEach(
+                        (channel: IChannel, channelIndex: number) => {
+                            if (faderIndex === channel.assignedFader) {
+                                this.mixerConnection[
+                                    mixerIndex
+                                ].updateMuteState(
+                                    channelIndex,
+                                    state.faders[0].fader[faderIndex].muteOn
+                                )
+                            }
                         }
-                    }
-                )
+                    )
+                }
             }
         )
     }

--- a/server/src/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/src/utils/mixerConnections/OscMixerConnection.ts
@@ -243,7 +243,11 @@ export class OscMixerConnection {
                         global.mainThreadHandler.updatePartialStore(
                             assignedFaderIndex
                         )
-                        mixerGenericConnection.updateOutLevel(assignedFaderIndex, 0, this.mixerIndex)
+                        mixerGenericConnection.updateOutLevel(
+                            assignedFaderIndex,
+                            0,
+                            this.mixerIndex
+                        )
                         if (remoteConnections) {
                             remoteConnections.updateRemoteFaderState(
                                 assignedFaderIndex,
@@ -328,6 +332,11 @@ export class OscMixerConnection {
                                 .channel[ch - 1].assignedFader,
                             message.args[0] === 0
                         )
+                    )
+                    mixerGenericConnection.updateMuteState(
+                        state.channels[0].chMixerConnection[this.mixerIndex]
+                            .channel[ch - 1].assignedFader,
+                        this.mixerIndex
                     )
                     global.mainThreadHandler.updatePartialStore(
                         state.channels[0].chMixerConnection[this.mixerIndex]

--- a/server/src/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/src/utils/mixerConnections/OscMixerConnection.ts
@@ -4,7 +4,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { store, state } from '../../reducers/store'
-import { remoteConnections } from '../../mainClasses'
+import { mixerGenericConnection, remoteConnections } from '../../mainClasses'
 
 //Utils:
 import {
@@ -243,7 +243,7 @@ export class OscMixerConnection {
                         global.mainThreadHandler.updatePartialStore(
                             assignedFaderIndex
                         )
-
+                        mixerGenericConnection.updateOutLevel(assignedFaderIndex, 0, this.mixerIndex)
                         if (remoteConnections) {
                             remoteConnections.updateRemoteFaderState(
                                 assignedFaderIndex,

--- a/server/src/utils/mixerConnections/SSLMixerConnection.ts
+++ b/server/src/utils/mixerConnections/SSLMixerConnection.ts
@@ -1,7 +1,7 @@
 //Node Modules:
 import net from 'net'
 import { store, state } from '../../reducers/store'
-import { remoteConnections } from '../../mainClasses'
+import { mixerGenericConnection, remoteConnections } from '../../mainClasses'
 
 //Utils:
 import {
@@ -95,6 +95,7 @@ export class SSLMixerConnection {
                                     channel.assignedFader === ch[channelIndex].assignedFader
                                 ) {
                                     this.updateOutLevel(index)
+
                                 }
                             })
                         }
@@ -119,6 +120,7 @@ export class SSLMixerConnection {
                     )
                 }
                 global.mainThreadHandler.updatePartialStore(ch[channelIndex].assignedFader)
+                mixerGenericConnection.updateOutLevel(ch[channelIndex].assignedFader, 0, this.mixerIndex)
             }
         } catch (error) {
             logger.error(

--- a/server/src/utils/mixerConnections/SSLMixerConnection.ts
+++ b/server/src/utils/mixerConnections/SSLMixerConnection.ts
@@ -169,6 +169,7 @@ export class SSLMixerConnection {
                 }
             }
         )
+        mixerGenericConnection.updateMuteState(assignedFaderIndex, this.mixerIndex)
         global.mainThreadHandler.updatePartialStore(assignedFaderIndex)
     }
 

--- a/server/src/utils/remoteConnections/HuiMidiRemoteConnection.ts
+++ b/server/src/utils/remoteConnections/HuiMidiRemoteConnection.ts
@@ -90,7 +90,7 @@ export class HuiMidiRemoteConnection {
                             this.convertFromRemoteLevel(message.data[2])
                         )
                     )
-                    mixerGenericConnection.updateOutLevel(message.data[1])
+                    mixerGenericConnection.updateOutLevel(message.data[1], -1)
                     this.updateRemoteFaderState(
                         message.data[1],
                         this.convertFromRemoteLevel(message.data[2])
@@ -104,14 +104,14 @@ export class HuiMidiRemoteConnection {
                         //SELECT button - toggle PGM ON/OFF
                         store.dispatch(storeTogglePgm(this.activeHuiChannel))
                         mixerGenericConnection.updateOutLevel(
-                            this.activeHuiChannel
+                            this.activeHuiChannel, -1
                         )
                         this.updateRemotePgmPstPfl(this.activeHuiChannel)
                     } else if (message.data[2] && message.data[2] === 67) {
                         //SOLO button - toggle PFL ON/OFF
                         store.dispatch(storeTogglePfl(this.activeHuiChannel))
                         mixerGenericConnection.updateOutLevel(
-                            this.activeHuiChannel
+                            this.activeHuiChannel, -1
                         )
                         this.updateRemotePgmPstPfl(this.activeHuiChannel)
                     }

--- a/server/src/utils/remoteConnections/SkaarhojRemoteConnection.ts
+++ b/server/src/utils/remoteConnections/SkaarhojRemoteConnection.ts
@@ -121,7 +121,7 @@ export class SkaarhojRemoteConnection {
             //Fader changed:
             logger.debug(`Received Fader ${channelIndex + 1} Level : ${level}`)
             store.dispatch(storeFaderLevel(channelIndex, level))
-            mixerGenericConnection.updateOutLevel(channelIndex)
+            mixerGenericConnection.updateOutLevel(channelIndex, -1)
             global.mainThreadHandler.updatePartialStore(channelIndex)
             this.updateRemoteFaderState(channelIndex, level)
         } else if (btnNumber > 80) {


### PR DESCRIPTION
feat: SSL hw controller should be able to control a Midas/Behringer mixer.
added support level and mute for updating all other mixers but the one that sends the command.

Note: This feat has been added with as little refactoring as possible.