### PR TITLE
fix(vmix): don't crash when vmix has more audio channels than sisyfos is configured to handle

### DIFF
--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -168,10 +168,7 @@ export class VMixMixerConnection {
 
                 // If vMix has more channels than Sisyfos is configured to handle,
                 // then do nothing with those additional channels.
-                if (
-                    !state.channels[0].chMixerConnection[this.mixerIndex]
-                        .channel[input.number - 1]
-                ) {
+                if (!this.doesChannelExists(input.number - 1)) {
                     return
                 }
 
@@ -675,5 +672,11 @@ export class VMixMixerConnection {
 
     injectCommand(command: string[]) {
         return true
+    }
+
+    doesChannelExists(channelNumber: number): boolean {
+        return !!state.channels[0].chMixerConnection[this.mixerIndex].channel[
+            channelNumber
+        ]
     }
 }

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -166,6 +166,16 @@ export class VMixMixerConnection {
                     ) // add +15 to convert from dBFS
                 }
 
+                // If vMix has more channels than Sisyfos is configured to handle,
+                // then do nothing with those additional channels.
+                if (
+                    input.number - 1 >
+                    state.channels[0].chMixerConnection[this.mixerIndex].channel
+                        .length
+                ) {
+                    return
+                }
+
                 const { outputLevel, fadeActive, assignedFader } =
                     state.channels[0].chMixerConnection[this.mixerIndex]
                         .channel[input.number - 1]

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -169,9 +169,8 @@ export class VMixMixerConnection {
                 // If vMix has more channels than Sisyfos is configured to handle,
                 // then do nothing with those additional channels.
                 if (
-                    input.number - 1 >
-                    state.channels[0].chMixerConnection[this.mixerIndex].channel
-                        .length
+                    !state.channels[0].chMixerConnection[this.mixerIndex]
+                        .channel[input.number - 1]
                 ) {
                     return
                 }


### PR DESCRIPTION
This PR is being opened on behalf of [TV 2 Norge](https://github.com/tv2norge).

Closes #255 

This is a naive solution from someone who is new to Sisyfos. It is possible that this has repercussions and consequences that I am not aware of. But, it does get Sisyfos to at least run for me.