### PR TITLE
Allow fade times to be set with each level change

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ To set the state send these OSC commands from you Automation to ProducersAudioMi
 
 #### Set channel faderlevel:
 
-/ch/1/mix/faderlevel - float {between 0 and 1}
+(the first defines the fader level)
+(if second is missing it will take default fade value)
+/ch/1/mix/faderlevel - float {between 0 and 1} - float { fadetime in ms }
 
 #### Set channel label:
 

--- a/server/src/utils/AutomationConnection.ts
+++ b/server/src/utils/AutomationConnection.ts
@@ -147,7 +147,14 @@ export class AutomationConnection {
             } else if (check('CHANNEL_FADER_LEVEL')) {
                 wrapChannelCommand((ch: any) => {
                     store.dispatch(storeFaderLevel(ch - 1, message.args[0]))
-                    mixerGenericConnection.updateOutLevel(ch - 1, -1)
+                    if (message.args.length > 1) {
+                        mixerGenericConnection.updateOutLevel(
+                            ch - 1,
+                            parseFloat(message.args[1])
+                        )
+                    } else {
+                        mixerGenericConnection.updateOutLevel(ch - 1, -1)
+                    }
                     global.mainThreadHandler.updatePartialStore(ch - 1)
                 })
             } else if (check('INJECT_COMMAND')) {

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -495,7 +495,7 @@ export class MixerGenericConnection {
         const currentTimeMS = Date.now()
         const elapsedTimeMS = currentTimeMS - startTimeAsMs
 
-        if (elapsedTimeMS >= fadeTime) {
+        if (elapsedTimeMS >= fadeTime || endLevel === startLevel) {
             this.mixerConnection[mixerIndex].updateFadeIOLevel(
                 channelIndex,
                 endLevel


### PR DESCRIPTION
To allow fade times to be adjusted with each level change this PR adds an additional (optional) `fadeTime` argument to the `/ch/1/mix/faderlevel` command.

Additionally this PR prevents fades from occurring if the start and end levels are the same.