### PR TITLE
Fix/ch strip follows pfl crash on midas

### DIFF
--- a/server/src/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/src/utils/mixerConnections/OscMixerConnection.ts
@@ -591,7 +591,7 @@ export class OscMixerConnection {
             state.channels[0].chMixerConnection[this.mixerIndex].channel[
                 channelIndex
             ].channelTypeIndex
-        if (state.faders[0].fader[channelIndex].pflOn === true) {
+        if (state.faders[0].fader[channelIndex].pflOn === true && this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON) {
             this.sendOutMessage(
                 this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
                     .mixerMessage,
@@ -601,7 +601,7 @@ export class OscMixerConnection {
                 this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
                     .type
             )
-        } else {
+        } else if (state.faders[0].fader[channelIndex].pflOn === false && this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF) {
             this.sendOutMessage(
                 this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF[0]
                     .mixerMessage,

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -195,6 +195,9 @@ export class VMixMixerConnection {
                     state.channels[0].chMixerConnection[this.mixerIndex]
                         .channel[input.number - 1]
                 const assignedFaderIndex = this.getAssignedFaderIndex(input.number - 1)
+                if (!state.faders[0].fader[assignedFaderIndex]) {
+                    return
+                }
                 const { inputGain, muteOn, pflOn, pgmOn, voOn } =
                     state.faders[0].fader[assignedFaderIndex]
                 let sendUpdate = false


### PR DESCRIPTION
When using Channel Strip follows PFL with a Midas mixer, Sisyfos would crash.
Reason: Solo function from Midas is not implemented.
As the OSCmixer protocol are used with other mixers than Midas it now checks if the Mixer has this feature implemented.
