### PR TITLE
fix: PFL follows ch-strip crash on midas, as PFL is not available on …

### DIFF
--- a/server/src/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/src/utils/mixerConnections/OscMixerConnection.ts
@@ -591,7 +591,7 @@ export class OscMixerConnection {
             state.channels[0].chMixerConnection[this.mixerIndex].channel[
                 channelIndex
             ].channelTypeIndex
-        if (state.faders[0].fader[channelIndex].pflOn === true) {
+        if (state.faders[0].fader[channelIndex].pflOn === true && this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON) {
             this.sendOutMessage(
                 this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
                     .mixerMessage,
@@ -601,7 +601,7 @@ export class OscMixerConnection {
                 this.mixerProtocol.channelTypes[channelType].toMixer.PFL_ON[0]
                     .type
             )
-        } else {
+        } else if (state.faders[0].fader[channelIndex].pflOn === false && this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF) {
             this.sendOutMessage(
                 this.mixerProtocol.channelTypes[channelType].toMixer.PFL_OFF[0]
                     .mixerMessage,


### PR DESCRIPTION
Problem: Turning on Channelstrip follows PFL would crash Sisyfos when using Midas mixer.
Reason: PFL is implemented on OSC mixerconnection but not on the Midas mixerprotocol.
Solution: As the OSC mixerconnection is user for several mixerprotocols, a check for implementation of PFL is made prior to sending PFL to the mixer.

