### PR TITLE
Fix some small issues around first startup

### DIFF
--- a/client/src/components/ChannelRouteSettings.tsx
+++ b/client/src/components/ChannelRouteSettings.tsx
@@ -96,9 +96,9 @@ class ChannelRouteSettings extends React.PureComponent<
 
     getAssignedToFaderIndex = (channel: IChannelReference): number => {
         let assignedFaderIndex = -1
-        this.props.fader.forEach((fader: any, index: number) => {
+        this.props.fader.forEach((fader, index: number) => {
 
-            if (fader.assignedChannels.some((assignedChan: IChannelReference) => {
+            if (fader.assignedChannels?.some((assignedChan: IChannelReference) => {
                 return assignedChan.channelIndex === channel.channelIndex && assignedChan.mixerIndex === channel.mixerIndex
             }))
                 assignedFaderIndex = index

--- a/server/src/MainThreadHandler.ts
+++ b/server/src/MainThreadHandler.ts
@@ -53,6 +53,8 @@ export class MainThreadHandlers {
     }
 
     updatePartialStore(faderIndex: number) {
+        if (faderIndex >= state.settings[0].numberOfFaders) return
+
         socketServer.emit(IO.SOCKET_SET_STORE_FADER, {
             faderIndex: faderIndex,
             state: state.faders[0].fader[faderIndex],

--- a/server/src/utils/SettingsStorage.ts
+++ b/server/src/utils/SettingsStorage.ts
@@ -17,6 +17,7 @@ import { defaultFadersReducerState } from '../../../shared/src/reducers/fadersRe
 import {
     IChannels,
     InumberOfChannels,
+    defaultChannelsReducerState,
 } from '../../../shared/src/reducers/channelsReducer'
 
 import {
@@ -111,7 +112,13 @@ export const loadSnapshotState = (
                     numberOfFaders
                 )
             )
-            logger.data(error).error('Initializing empty faders')
+            store.dispatch(
+                storeSetCompleteChState(
+                    defaultChannelsReducerState(numberOfChannels)[0],
+                    numberOfChannels
+                )
+            )
+            logger.data(error).error('Initializing empty faders/channels')
         } else {
             logger.data(error).error('Error loading Snapshot')
         }

--- a/server/src/utils/SettingsStorage.ts
+++ b/server/src/utils/SettingsStorage.ts
@@ -108,7 +108,7 @@ export const loadSnapshotState = (
         if (fileName.includes('default.shot')) {
             store.dispatch(
                 storeSetCompleteFaderState(
-                    defaultFadersReducerState(numberOfFaders)[0],
+                    defaultFadersReducerState(numberOfFaders, numberOfChannels)[0],
                     numberOfFaders
                 )
             )

--- a/server/src/utils/migrations.ts
+++ b/server/src/utils/migrations.ts
@@ -3,10 +3,9 @@ import path from 'path'
 
 import { logger } from './logger'
 import { ISettings } from '../../../shared/src/reducers/settingsReducer'
-import { getSnapShotList, IShotStorage } from './SettingsStorage'
+import { getSnapShotList, IShotStorage, STORAGE_FOLDER } from './SettingsStorage'
 
 const version = process.env.npm_package_version
-const settingsPath: string = path.resolve(process.cwd(), 'storage')
 
 export const checkVersion = (currentSettings: ISettings): ISettings => {
     if (
@@ -34,39 +33,40 @@ const migrate45to47 = (currentSettings: ISettings): ISettings => {
     files.push('default.shot')
 
     files.forEach((fileName: string) => {
-        let stateFromShot = JSON.parse(
-            fs.readFileSync(path.join(settingsPath, fileName), 'utf8')
-        )
-        // As this is the first implemented migration it also looks .shot files from ealier versions than 4.xx
-        if (stateFromShot.channelState.chConnection) {
-            // From Version 4.xx
-            stateFromShot.channelState.chMixerConnection =
-                stateFromShot.channelState?.chConnection
-            delete stateFromShot.channelState.chConnection
-        } else if (stateFromShot.channelState.channel) {
-            // Version lower than 4.0
-            stateFromShot.channelState.chMixerConnection = [
-                { channel: stateFromShot.channelState.channel },
-            ]
-            delete stateFromShot.channelState.channel
-        }
-        let migratedShot: IShotStorage = stateFromShot
         try {
+            let stateFromShot = JSON.parse(
+                fs.readFileSync(path.join(STORAGE_FOLDER, fileName), 'utf8')
+            )
+            // As this is the first implemented migration it also looks .shot files from ealier versions than 4.xx
+            if (stateFromShot.channelState.chConnection) {
+                // From Version 4.xx
+                stateFromShot.channelState.chMixerConnection =
+                    stateFromShot.channelState?.chConnection
+                delete stateFromShot.channelState.chConnection
+            } else if (stateFromShot.channelState.channel) {
+                // Version lower than 4.0
+                stateFromShot.channelState.chMixerConnection = [
+                    { channel: stateFromShot.channelState.channel },
+                ]
+                delete stateFromShot.channelState.channel
+            }
+            let migratedShot: IShotStorage = stateFromShot
+            
             fs.writeFileSync(
-                path.join(settingsPath, fileName),
+                path.join(STORAGE_FOLDER, fileName),
                 JSON.stringify(migratedShot),
                 'utf8'
             )
             logger.trace(`Snapshot ${fileName} Saved to storage folder`)
-        } catch (error: any) {
-            logger.data(error).error('Error saving Snapshot')
+        } catch (error) {
+            logger.data(error).error('Error migrating Snapshot')
         }
     })
     currentSettings.sisyfosVersion = version
     delete currentSettings.customPages
     try {
         fs.writeFileSync(
-            path.join(settingsPath, 'settings.json'),
+            path.join(STORAGE_FOLDER, 'settings.json'),
             JSON.stringify(currentSettings),
             'utf8'
         )

--- a/server/src/utils/mixerConnections/CasparCGConnection.ts
+++ b/server/src/utils/mixerConnections/CasparCGConnection.ts
@@ -23,6 +23,7 @@ import { IFader } from '../../../../shared/src/reducers/fadersReducer'
 import { sendVuLevel } from '../vuServer'
 import { VuType } from '../../../../shared/src/utils/vu-server-types'
 import { storeSetMixerOnline } from '../../../../shared/src/actions/settingsActions'
+import { STORAGE_FOLDER } from '../SettingsStorage'
 
 interface CommandChannelMap {
     [key: string]: number
@@ -85,8 +86,7 @@ export class CasparCGConnection {
 
     injectCasparCGSetting() {
         const geometryFile = path.resolve(
-            process.cwd(),
-            'storage',
+            STORAGE_FOLDER,
             'default-casparcg.ccg'
         )
 

--- a/server/src/utils/mixerConnections/EmberMixerConnection.ts
+++ b/server/src/utils/mixerConnections/EmberMixerConnection.ts
@@ -32,6 +32,7 @@ import {
     IFader,
 } from '../../../../shared/src/reducers/fadersReducer'
 import { EmberElement, NumberedTreeNode } from 'emberplus-connection/dist/model'
+import { STORAGE_FOLDER } from '../SettingsStorage'
 
 export class EmberMixerConnection {
     mixerProtocol: IMixerProtocol
@@ -892,7 +893,7 @@ export class EmberMixerConnection {
             let data = JSON.parse(
                 fs
                     .readFileSync(
-                        path.resolve(process.cwd(), 'storage', presetName)
+                        path.resolve(STORAGE_FOLDER, presetName)
                     )
                     .toString()
             )

--- a/server/src/utils/mixerConnections/LawoRubyConnection.ts
+++ b/server/src/utils/mixerConnections/LawoRubyConnection.ts
@@ -16,6 +16,7 @@ import {
     storeCapability,
     storeShowChannel,
     storeSetPgm,
+    storeInputSelector,
 } from '../../../../shared/src/actions/faderActions'
 import { logger } from '../logger'
 import { storeSetMixerOnline } from '../../../../shared/src/actions/settingsActions'
@@ -367,11 +368,10 @@ export class LawoRubyMixerConnection {
                                 selector.value ===
                                 (node.contents as Model.Parameter).value
                             ) {
-                                store.dispatch({
-                                    type: SET_INPUT_SELECTOR,
-                                    channel: ch - 1,
-                                    selected: i + 1,
-                                })
+                                store.dispatch(storeInputSelector(
+                                    ch - 1,
+                                    i + 1
+                                ))
                                 global.mainThreadHandler.updatePartialStore(
                                     ch - 1
                                 )

--- a/server/src/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/src/utils/mixerConnections/OscMixerConnection.ts
@@ -30,6 +30,7 @@ import { sendVuLevel } from '../vuServer'
 import { VuType } from '../../../../shared/src/utils/vu-server-types'
 import { IChannelReference, IFader } from '../../../../shared/src/reducers/fadersReducer'
 import { IChannel } from '../../../../shared/src/reducers/channelsReducer'
+import { STORAGE_FOLDER } from '../SettingsStorage'
 
 interface IOscCommand {
     address: string
@@ -739,7 +740,7 @@ export class OscMixerConnection {
         if (this.mixerProtocol.presetFileExtension === 'X32') {
             let data = JSON.parse(
                 fs.readFileSync(
-                    path.resolve(process.cwd(), 'storage', presetName),
+                    path.resolve(STORAGE_FOLDER, presetName),
                     'utf8'
                 )
             )

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -685,7 +685,7 @@ export class VMixMixerConnection {
         logger.info(`Loading preset : ${presetName}`)
         if (this.mixerProtocol.presetFileExtension === 'X32') {
             let data = JSON.parse(
-                '{}' // ''fs.readFileSync(path.resolve(process.cwd(), 'storage', presetName))
+                '{}' // ''fs.readFileSync(path.resolve(STORAGE_FOLDER, presetName))
             )
 
             this.vmixConnection.send({

--- a/shared/src/reducers/channelsReducer.ts
+++ b/shared/src/reducers/channelsReducer.ts
@@ -35,7 +35,7 @@ export interface InumberOfChannels {
     numberOfTypeInCh: number[]
 }
 
-const defaultChannelsReducerState = (
+export const defaultChannelsReducerState = (
     numberOfChannels: InumberOfChannels[]
 ): IChannels[] => {
     let defaultObj: IChannels[] = [
@@ -82,6 +82,13 @@ export const channels = (
             chMixerConnection: [...state[0].chMixerConnection],
         },
     ]
+
+    if ('mixerIndex' in action && nextState[0].chMixerConnection[action.mixerIndex] === undefined) {
+        return nextState
+    }
+    if ('mixerIndex' in action && 'channel' in action && nextState[0].chMixerConnection[action.mixerIndex]?.channel[action.channel] === undefined) {
+        return nextState
+    }
 
     switch (action.type) {
         case SET_OUTPUT_LEVEL:

--- a/shared/src/reducers/fadersReducer.ts
+++ b/shared/src/reducers/fadersReducer.ts
@@ -1,4 +1,5 @@
 import * as FADER_ACTIONS from '../actions/faderActions'
+import { InumberOfChannels } from './channelsReducer'
 export interface IFaders {
     fader: Array<IFader>
     vuMeters: Array<IVuMeters>
@@ -46,7 +47,8 @@ export interface IVuMeters {
 }
 
 export const defaultFadersReducerState = (
-    numberOfFaders: number
+    numberOfFaders: number,
+    numberOfChannels?: InumberOfChannels[]
 ): IFaders[] => {
     let defaultObj: Array<IFaders> = [
         {
@@ -54,6 +56,19 @@ export const defaultFadersReducerState = (
             vuMeters: [],
         },
     ]
+
+    const channels: IChannelReference[] = []
+    for (let mixerIndex = 0; mixerIndex < numberOfChannels?.length ?? 0; mixerIndex++) {
+        const mixer = numberOfChannels[mixerIndex]
+        let channelIndex = 0
+        for (const typeCount of mixer.numberOfTypeInCh) {
+            for (let i = 0; i < typeCount; i++) {
+                channels.push({ mixerIndex, channelIndex })
+                channelIndex++
+            }
+        }
+    }
+    console.log(channels)
 
     for (let index = 0; index < numberOfFaders; index++) {
         defaultObj[0].fader[index] = {
@@ -74,6 +89,8 @@ export const defaultFadersReducerState = (
             showInMiniMonitor: false,
             ignoreAutomation: false,
             disabled: false,
+
+            assignedChannels: channels[index] ? [channels[index]] : []
         }
         defaultObj[0].vuMeters.push({
             reductionVal: 0.0,


### PR DESCRIPTION
Hi, I've found and fixed some issues that I've found when starting up Sisyfos for the very first time (i.e. no saved files):

- On MacOS the storage path was inconsistent, causing the default snapshot to be saved in a different place than it was opened from.
- Some robustness about dispatching updates to the channels, now it checks if the mixerIndex and channelIndex are actually valid for the store.
- I've changed some code so that all channels are initialised immediately upon first start and all the faders are routed 1:1. Makes it a bit easier to restore from just a settings file.

Just for transparency: these changes are contributed by SuperFly.tv on behalf of BBC. (Just putting this here as I usually contribute on behalf of NRK)