### PR TITLE
Mixer output level subscription

### DIFF
--- a/server/src/expressHandler.ts
+++ b/server/src/expressHandler.ts
@@ -22,7 +22,7 @@ const staticPath = path.join(
 logger.data(staticPath).debug('Express static file path:')
 app.use(ROOT_PATH, express.static(staticPath))
 server.listen(SERVER_PORT)
-logger.info(`Server started at http://localhost:${SERVER_PORT}/${ROOT_PATH}`)
+logger.info(`Server started at http://localhost:${SERVER_PORT}${ROOT_PATH}`)
 
 socketServer.on('connection', (socket: any) => {
     logger.info(`Client connected: ${socket.client.id}`)

--- a/server/src/expressHandler.ts
+++ b/server/src/expressHandler.ts
@@ -1,5 +1,6 @@
 import { logger } from './utils/logger'
 import { socketSubscribeVu, socketUnsubscribeVu } from './utils/vuServer'
+import { socketSubscribeOutputLevel, socketUnsubscribeOutputLevel } from './utils/outputLevelServer'
 
 import express from 'express'
 import path from 'path'
@@ -31,8 +32,13 @@ socketServer.on('connection', (socket: any) => {
         logger.debug('Socket subscribe vu')
         socketSubscribeVu(socket)
     })
+    socket.on('subscribe-output-level', () => {
+        logger.debug('Socket subscribe output')
+        socketSubscribeOutputLevel(socket)
+    })
     socket.on('disconnect', () => {
         socketUnsubscribeVu(socket)
+        socketUnsubscribeOutputLevel(socket)
     })
 })
 

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -30,6 +30,7 @@ import {
 } from '../../../shared/src/actions/faderActions'
 import { AtemMixerConnection } from './mixerConnections/AtemConnection'
 import { IChannelReference } from '../../../shared/src/reducers/fadersReducer'
+import { sendOutputLevel } from './outputLevelServer'
 
 export class MixerGenericConnection {
     mixerProtocol: IMixerProtocolGeneric[]
@@ -517,6 +518,7 @@ export class MixerGenericConnection {
                 channel: channelIndex,
                 level: endLevel,
             })
+            sendOutputLevel(mixerIndex, channelIndex, endLevel)
             this.delayedFadeActiveDisable(mixerIndex, channelIndex)
             return true
         }
@@ -537,6 +539,7 @@ export class MixerGenericConnection {
             channel: channelIndex,
             level: endLevel,
         })
+        sendOutputLevel(mixerIndex, channelIndex, currentOutputLevel)
     }
 
     fadeDown = (mixerIndex: number, channelIndex: number, fadeTime: number) => {

--- a/server/src/utils/outputLevelServer.ts
+++ b/server/src/utils/outputLevelServer.ts
@@ -1,0 +1,25 @@
+const sockets: Array<any> = []
+
+export function socketSubscribeOutputLevel(socket: any) {
+    const i = sockets.indexOf(socket)
+    if (i === -1) {
+        sockets.push(socket)
+    }
+}
+
+export function socketUnsubscribeOutputLevel(socket: any) {
+    const i = sockets.indexOf(socket)
+    if (i >= 0) {
+        sockets.splice(i, 1)
+    }
+}
+
+export function sendOutputLevel(
+    mixerIndex: number,
+    channelIndex: number,
+    level: number
+) {
+    sockets.forEach((socket) => {
+        socket.emit('outputLevel', mixerIndex, channelIndex, level)
+    })
+}


### PR DESCRIPTION
Adds an additional subscription option for the Socket.IO connection to get the output level of the mixer.

Intended for use with remote fader panel applications where real-time updates of the levels are required.