### PR TITLE
chore: all interfaces renamed so i infront of name is removed.

### DIFF
--- a/client/index.tsx
+++ b/client/index.tsx
@@ -16,13 +16,13 @@ import {
 
 import { I18nextProvider } from 'react-i18next'
 import i18n from './src/utils/i18n'
-import { IMixerProtocol } from '../shared/src/constants/MixerProtocolInterface'
+import { MixerProtocol } from '../shared/src/constants/MixerProtocolInterface'
 
 declare global {
     interface Window {
         storeRedux: any
         reduxState: any
-        mixerProtocol: IMixerProtocol
+        mixerProtocol: MixerProtocol
         mixerProtocolPresets: any
         mixerProtocolList: any
         socketIoClient: any

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
-import { IStore } from '../../../shared/src/reducers/store'
+import { ReduxStore } from '../../../shared/src/reducers/store'
 
 import '../assets/css/App.css'
 import Channels from './Channels'
@@ -13,13 +13,13 @@ import { withTranslation } from 'react-i18next'
 import PagesSettings from './PagesSettings'
 import LabelSettings from './Labels'
 
-export interface IAppProps {
-    store: IStore
+export interface AppProps {
+    store: ReduxStore
     t: any
 }
 
-class App extends React.Component<IAppProps> {
-    constructor(props: IAppProps) {
+class App extends React.Component<AppProps> {
+    constructor(props: AppProps) {
         super(props)
     }
 
@@ -38,7 +38,7 @@ class App extends React.Component<IAppProps> {
         this.contextMenuHandler()
     }
 
-    public shouldComponentUpdate(nextProps: IAppProps) {
+    public shouldComponentUpdate(nextProps: AppProps) {
         return (
             nextProps.store.settings[0].showSettings !=
                 this.props.store.settings[0].showSettings ||
@@ -133,7 +133,7 @@ class App extends React.Component<IAppProps> {
     }
 }
 
-const mapStateToProps = (state: any, t: any): IAppProps => {
+const mapStateToProps = (state: any, t: any): AppProps => {
     return {
         store: state,
         t: t,
@@ -141,6 +141,6 @@ const mapStateToProps = (state: any, t: any): IAppProps => {
 }
 
 export default compose(
-    connect<any, IAppProps>(mapStateToProps),
+    connect<any, AppProps>(mapStateToProps),
     withTranslation()
 )(App) as any

--- a/client/src/components/ChanStrip.tsx
+++ b/client/src/components/ChanStrip.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 import {
     SettingsActionTypes,
 } from '../../../shared/src/actions/settingsActions'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
 import {
     SOCKET_SET_FX,
     SOCKET_SET_AUX_LEVEL,
@@ -19,17 +19,17 @@ import ClassNames from 'classnames'
 import { fxParamsList } from '../../../shared/src/constants/MixerProtocolInterface'
 import { getFaderLabel } from '../utils/labels'
 
-interface IChanStripInjectProps {
+interface ChanStripInjectProps {
     label: string
     selectedProtocol: string
     numberOfChannelsInType: Array<number>
     channel: Array<any>
-    fader: Array<IFader>
+    fader: Array<Fader>
     auxSendIndex: number
     offtubeMode: boolean
 }
 
-interface IChanStripProps {
+interface ChanStripProps {
     faderIndex: number
 }
 
@@ -37,7 +37,7 @@ interface IChanStripProps {
 const DEL_VALUES = [10, 1, -1, -10]
 
 class ChanStrip extends React.PureComponent<
-    IChanStripProps & IChanStripInjectProps & Store
+    ChanStripProps & ChanStripInjectProps & Store
 > {
     constructor(props: any) {
         super(props)
@@ -514,8 +514,8 @@ class ChanStrip extends React.PureComponent<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IChanStripInjectProps => {
-    let inject: IChanStripInjectProps = {
+const mapStateToProps = (state: any, props: any): ChanStripInjectProps => {
+    let inject: ChanStripInjectProps = {
         label: '',
         selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
         numberOfChannelsInType:
@@ -540,6 +540,6 @@ const mapStateToProps = (state: any, props: any): IChanStripInjectProps => {
     return inject
 }
 
-export default connect<any, IChanStripInjectProps>(mapStateToProps)(
+export default connect<any, ChanStripInjectProps>(mapStateToProps)(
     ChanStrip
 ) as any

--- a/client/src/components/ChanStripEq.tsx
+++ b/client/src/components/ChanStripEq.tsx
@@ -5,23 +5,23 @@ import ReactSlider from 'react-slider'
 import '../assets/css/ChanStripEq.css'
 import { Store } from 'redux'
 import { connect } from 'react-redux'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
-import { IChannel } from '../../../shared/src/reducers/channelsReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
+import { Channel } from '../../../shared/src/reducers/channelsReducer'
 import { SOCKET_SET_FX } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 import { fxParamsList } from '../../../shared/src/constants/MixerProtocolInterface'
 import { getFaderLabel } from '../utils/labels'
 
-interface IChanStripFullInjectProps {
+interface ChanStripFullInjectProps {
     label: string
     selectedProtocol: string
     numberOfChannelsInType: Array<number>
-    channel: IChannel[]
-    fader: IFader[]
+    channel: Channel[]
+    fader: Fader[]
     auxSendIndex: number
     offtubeMode: boolean
 }
 
-interface IChanStripFullProps {
+interface ChanStripFullProps {
     faderIndex: number
 }
 
@@ -32,11 +32,11 @@ enum EqColors {
     'rgb(229, 159, 34)',
 }
 
-interface IFreqLabels {
+interface FreqLabels {
     label: string
     posY: number
 }
-const EQ_FREQ_LABELS: IFreqLabels[] = [
+const EQ_FREQ_LABELS: FreqLabels[] = [
     {
         label: '50',
         posY: 340,
@@ -84,7 +84,7 @@ const EQ_Y_SIZE = 0.25
 const EQ_Y_OFFSET = 0.55
 
 class ChanStripEq extends React.PureComponent<
-    IChanStripFullProps & IChanStripFullInjectProps & Store
+    ChanStripFullProps & ChanStripFullInjectProps & Store
 > {
     canvas: HTMLCanvasElement | undefined
 
@@ -93,7 +93,7 @@ class ChanStripEq extends React.PureComponent<
     }
 
     shouldComponentUpdate(
-        nextProps: IChanStripFullInjectProps & IChanStripFullProps
+        nextProps: ChanStripFullInjectProps & ChanStripFullProps
     ) {
         if (nextProps.faderIndex > -1) {
             return true
@@ -195,7 +195,7 @@ class ChanStripEq extends React.PureComponent<
         context.stroke()
         // Freq on zero gain line:
         context.beginPath()
-        EQ_FREQ_LABELS.forEach((freq: IFreqLabels) => {
+        EQ_FREQ_LABELS.forEach((freq: FreqLabels) => {
             context.font = '30px Ariel'
             context.strokeStyle = 'white'
             context.strokeText(
@@ -425,8 +425,8 @@ class ChanStripEq extends React.PureComponent<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IChanStripFullInjectProps => {
-    let inject: IChanStripFullInjectProps = {
+const mapStateToProps = (state: any, props: any): ChanStripFullInjectProps => {
+    let inject: ChanStripFullInjectProps = {
         label: '',
         selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
         numberOfChannelsInType:
@@ -451,6 +451,6 @@ const mapStateToProps = (state: any, props: any): IChanStripFullInjectProps => {
     return inject
 }
 
-export default connect<any, IChanStripFullInjectProps>(mapStateToProps)(
+export default connect<any, ChanStripFullInjectProps>(mapStateToProps)(
     ChanStripEq
 ) as any

--- a/client/src/components/ChanStripFull.tsx
+++ b/client/src/components/ChanStripFull.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 import {
     SettingsActionTypes,
 } from '../../../shared/src/actions/settingsActions'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
 import {
     SOCKET_SET_FX,
     SOCKET_SET_AUX_LEVEL,
@@ -17,21 +17,21 @@ import {
 import ReductionMeter from './ReductionMeter'
 import ClassNames from 'classnames'
 import { fxParamsList } from '../../../shared/src/constants/MixerProtocolInterface'
-import { IChannel } from '../../../shared/src/reducers/channelsReducer'
+import { Channel } from '../../../shared/src/reducers/channelsReducer'
 import { getFaderLabel } from '../utils/labels'
 import ChanStripEq from './ChanStripEq'
 
-interface IChanStripFullInjectProps {
+interface ChanStripFullInjectProps {
     label: string
     selectedProtocol: string
     numberOfChannelsInType: Array<number>
-    channel: IChannel[]
-    fader: IFader[]
+    channel: Channel[]
+    fader: Fader[]
     auxSendIndex: number
     offtubeMode: boolean
 }
 
-interface IChanStripFullProps {
+interface ChanStripFullProps {
     faderIndex: number
 }
 
@@ -39,7 +39,7 @@ interface IChanStripFullProps {
 const DEL_VALUES = [10, 1, -1, -10]
 
 class ChanStripFull extends React.PureComponent<
-    IChanStripFullProps & IChanStripFullInjectProps & Store
+    ChanStripFullProps & ChanStripFullInjectProps & Store
 > {
 
     constructor(props: any) {
@@ -523,8 +523,8 @@ class ChanStripFull extends React.PureComponent<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IChanStripFullInjectProps => {
-    let inject: IChanStripFullInjectProps = {
+const mapStateToProps = (state: any, props: any): ChanStripFullInjectProps => {
+    let inject: ChanStripFullInjectProps = {
         label: '',
         selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
         numberOfChannelsInType:
@@ -549,6 +549,6 @@ const mapStateToProps = (state: any, props: any): IChanStripFullInjectProps => {
     return inject
 }
 
-export default connect<any, IChanStripFullInjectProps>(mapStateToProps)(
+export default connect<any, ChanStripFullInjectProps>(mapStateToProps)(
     ChanStripFull
 ) as any

--- a/client/src/components/Channel.tsx
+++ b/client/src/components/Channel.tsx
@@ -9,24 +9,24 @@ import '../assets/css/NoUiSlider.css'
 //assets:
 import '../assets/css/Channel.css'
 import * as IO from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
-import { IChannelReference, IFader } from '../../../shared/src/reducers/fadersReducer'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
+import { ChannelReference, Fader } from '../../../shared/src/reducers/fadersReducer'
+import { Settings } from '../../../shared/src/reducers/settingsReducer'
 import { SettingsActionTypes } from '../../../shared/src/actions/settingsActions'
 import { withTranslation } from 'react-i18next'
 import { MixerConnectionTypes, VuLabelConversionType } from '../../shared../../../shared/src/constants/MixerProtocolInterface'
 import { getFaderLabel } from '../utils/labels'
 import { Conversions } from '../../../shared/src/actions/utils/dbConversion'
 
-interface IChannelInjectProps {
+interface ChannelInjectProps {
     t: any
-    fader: IFader
-    settings: ISettings
+    fader: Fader
+    settings: Settings
     channelType: number
     channelTypeIndex: number
     label: string
 }
 
-interface IChannelProps {
+interface ChannelProps {
     faderIndex: number
 }
 
@@ -35,7 +35,7 @@ function XOR(a: any, b: any): boolean {
 }
 
 class Channel extends React.Component<
-    IChannelProps & IChannelInjectProps & Store
+    ChannelProps & ChannelInjectProps & Store
 > {
     faderIndex: number
 
@@ -46,7 +46,7 @@ class Channel extends React.Component<
         this.faderIndex = this.props.faderIndex
     }
 
-    public shouldComponentUpdate(nextProps: IChannelInjectProps) {
+    public shouldComponentUpdate(nextProps: ChannelInjectProps) {
         return (
             nextProps.channelTypeIndex !== this.props.channelTypeIndex ||
             nextProps.fader.pgmOn != this.props.fader.pgmOn ||
@@ -161,13 +161,13 @@ class Channel extends React.Component<
                 </React.Fragment>
             )
         } else {
-            let assignedChannels: IChannelReference[] = this.props.fader
+            let assignedChannels: ChannelReference[] = this.props.fader
                 .assignedChannels || [{ mixerIndex: 0, channelIndex: 0 }]
             return (
                 <React.Fragment>
                     {!window.location.search.includes('vu=0') &&
                         assignedChannels?.map(
-                            (assigned: IChannelReference, index) => (
+                            (assigned: ChannelReference, index) => (
                                 <VuMeter
                                     faderIndex={this.faderIndex}
                                     channel={index}
@@ -499,7 +499,7 @@ class Channel extends React.Component<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IChannelInjectProps => {
+const mapStateToProps = (state: any, props: any): ChannelInjectProps => {
     return {
         t: props.t,
         fader: state.faders[0].fader[props.faderIndex],
@@ -512,6 +512,6 @@ const mapStateToProps = (state: any, props: any): IChannelInjectProps => {
 }
 
 export default compose(
-    connect<any, IChannelInjectProps, any>(mapStateToProps),
+    connect<any, ChannelInjectProps, any>(mapStateToProps),
     withTranslation()
 )(Channel) as any

--- a/client/src/components/ChannelMonitorOptions.tsx
+++ b/client/src/components/ChannelMonitorOptions.tsx
@@ -5,7 +5,7 @@ import '../assets/css/ChannelMonitorOptions.css'
 import { Store } from 'redux'
 import { connect } from 'react-redux'
 import { SettingsActionTypes } from '../../../shared/src/actions/settingsActions'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
+import { Settings } from '../../../shared/src/reducers/settingsReducer'
 import {
     SOCKET_SET_AUX_LEVEL,
     SOCKET_SET_FADER_MONITOR,
@@ -13,21 +13,21 @@ import {
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 import { getFaderLabel } from '../utils/labels'
 
-interface IMonitorSettingsInjectProps {
+interface MonitorSettingsInjectProps {
     label: string
     selectedProtocol: string
     numberOfChannelsInType: Array<number>
     channel: Array<any>
     fader: Array<any>
-    settings: ISettings
+    settings: Settings
 }
 
-interface IChannelProps {
+interface ChannelProps {
     faderIndex: number
 }
 
 class ChannelMonitorOptions extends React.PureComponent<
-    IChannelProps & IMonitorSettingsInjectProps & Store
+    ChannelProps & MonitorSettingsInjectProps & Store
 > {
     faderIndex: number
 
@@ -192,7 +192,7 @@ class ChannelMonitorOptions extends React.PureComponent<
 const mapStateToProps = (
     state: any,
     props: any
-): IMonitorSettingsInjectProps => {
+): MonitorSettingsInjectProps => {
     return {
         label: getFaderLabel(props.faderIndex, 'FADER'),
         selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
@@ -204,6 +204,6 @@ const mapStateToProps = (
     }
 }
 
-export default connect<any, IMonitorSettingsInjectProps>(mapStateToProps)(
+export default connect<any, MonitorSettingsInjectProps>(mapStateToProps)(
     ChannelMonitorOptions
 ) as any

--- a/client/src/components/ChannelRouteSettings.tsx
+++ b/client/src/components/ChannelRouteSettings.tsx
@@ -6,22 +6,22 @@ import { Store } from 'redux'
 import { connect } from 'react-redux'
 import { SettingsActionTypes } from '../../../shared/src/actions/settingsActions'
 import { SOCKET_ASSIGN_CH_TO_FADER, SOCKET_REMOVE_ALL_CH_ASSIGNMENTS } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
-import { IchMixerConnection } from '../../../shared/src/reducers/channelsReducer'
-import { IChannelReference, IFader } from '../../../shared/src/reducers/fadersReducer'
+import { ChMixerConnection } from '../../../shared/src/reducers/channelsReducer'
+import { ChannelReference, Fader } from '../../../shared/src/reducers/fadersReducer'
 import { getFaderLabel } from '../utils/labels'
 
-interface IChannelSettingsInjectProps {
+interface ChannelSettingsInjectProps {
     label: string
-    chMixerConnections: IchMixerConnection[]
-    fader: IFader[]
+    chMixerConnections: ChMixerConnection[]
+    fader: Fader[]
 }
 
-interface IChannelProps {
+interface ChannelProps {
     faderIndex: number
 }
 
 class ChannelRouteSettings extends React.PureComponent<
-    IChannelProps & IChannelSettingsInjectProps & Store
+    ChannelProps & ChannelSettingsInjectProps & Store
 > {
     faderIndex: number
 
@@ -44,7 +44,7 @@ class ChannelRouteSettings extends React.PureComponent<
         ) {
             // Check if channel already is assigned to another fader and remove that binding prior to bind it to the new fader
             if (event.target.checked) {
-                this.props.fader.forEach((fader: IFader, index: number) => {
+                this.props.fader.forEach((fader: Fader, index: number) => {
                     if (fader.assignedChannels.some((assignedChan) => {
                         return assignedChan.mixerIndex === mixerIndex && assignedChan.channelIndex === channelIndex
                     })) {
@@ -97,11 +97,11 @@ class ChannelRouteSettings extends React.PureComponent<
         })
     }
 
-    getAssignedToFaderIndex = (channel: IChannelReference): number => {
+    getAssignedToFaderIndex = (channel: ChannelReference): number => {
         let assignedFaderIndex = -1
         this.props.fader.forEach((fader, index: number) => {
 
-            if (fader.assignedChannels?.some((assignedChan: IChannelReference) => {
+            if (fader.assignedChannels?.some((assignedChan: ChannelReference) => {
                 return assignedChan.channelIndex === channel.channelIndex && assignedChan.mixerIndex === channel.mixerIndex
             }))
                 assignedFaderIndex = index
@@ -110,7 +110,7 @@ class ChannelRouteSettings extends React.PureComponent<
     }
 
 
-    renderMixer(chMixerConnection: IchMixerConnection, mixerIndex: number) {
+    renderMixer(chMixerConnection: ChMixerConnection, mixerIndex: number) {
         return (
             <div>
                 <p className="channel-route-mixer-name">
@@ -175,7 +175,7 @@ class ChannelRouteSettings extends React.PureComponent<
                 </button>
                 <hr />
                 {this.props.chMixerConnections.map(
-                    (chMixerConnection: IchMixerConnection, mixerIndex: number) =>
+                    (chMixerConnection: ChMixerConnection, mixerIndex: number) =>
                         this.renderMixer(chMixerConnection, mixerIndex)
                 )}
             </div>
@@ -186,7 +186,7 @@ class ChannelRouteSettings extends React.PureComponent<
 const mapStateToProps = (
     state: any,
     props: any
-): IChannelSettingsInjectProps => {
+): ChannelSettingsInjectProps => {
     return {
         label: getFaderLabel(props.faderIndex, 'FADER'),
         chMixerConnections: state.channels[0].chMixerConnection,
@@ -194,6 +194,6 @@ const mapStateToProps = (
     }
 }
 
-export default connect<any, IChannelSettingsInjectProps>(mapStateToProps)(
+export default connect<any, ChannelSettingsInjectProps>(mapStateToProps)(
     ChannelRouteSettings
 ) as any

--- a/client/src/components/Channels.tsx
+++ b/client/src/components/Channels.tsx
@@ -11,12 +11,12 @@ import {
 import ChannelRouteSettings from './ChannelRouteSettings'
 import ChanStrip from './ChanStrip'
 import ChannelMonitorOptions from './ChannelMonitorOptions'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
-import { IChannels } from '../../../shared/src/reducers/channelsReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
+import { Channels as IChannels } from '../../../shared/src/reducers/channelsReducer'
 import {
-    ICustomPages,
-    IMixerSettings,
-    ISettings,
+    CustomPages,
+    MixerSettings,
+    Settings,
     PageType,
 } from '../../../shared/src/reducers/settingsReducer'
 import {
@@ -27,21 +27,21 @@ import {
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 import ChanStripFull from './ChanStripFull'
 
-interface IChannelsInjectProps {
+interface ChannelsInjectProps {
     channels: IChannels
-    faders: IFader[]
-    settings: ISettings
-    customPages: ICustomPages[]
+    faders: Fader[]
+    settings: Settings
+    customPages: CustomPages[]
     mixersOnline: boolean
 }
 
-class Channels extends React.Component<IChannelsInjectProps & Store> {
+class Channels extends React.Component<ChannelsInjectProps & Store> {
     constructor(props: any) {
         super(props)
         this.props.settings.showMonitorOptions = -1
     }
 
-    public shouldComponentUpdate(nextProps: IChannelsInjectProps) {
+    public shouldComponentUpdate(nextProps: ChannelsInjectProps) {
         return (
             this.props.settings.showOptions !==
                 nextProps.settings.showOptions ||
@@ -201,7 +201,7 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                 ))
             case PageType.CustomPage:
                 let pageIndex: number = this.props.customPages
-                    .map((item: ICustomPages) => item.id)
+                    .map((item: CustomPages) => item.id)
                     .indexOf(curPage.id || '')
                 return this.props.customPages[pageIndex].faders
                     .filter((value) => {
@@ -358,18 +358,18 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
     }
 }
 
-const mapStateToProps = (state: any): IChannelsInjectProps => {
+const mapStateToProps = (state: any): ChannelsInjectProps => {
     return {
         channels: state.channels[0].chMixerConnection[0].channel,
         faders: state.faders[0].fader,
         customPages: state.settings[0].customPages,
         settings: state.settings[0],
         mixersOnline: state.settings[0].mixers
-            .map((m: IMixerSettings) => m.mixerOnline)
+            .map((m: MixerSettings) => m.mixerOnline)
             .reduce((a: boolean, b: boolean) => a && b),
     }
 }
 
-export default connect<IChannelsInjectProps, any, any>(mapStateToProps)(
+export default connect<ChannelsInjectProps, any, any>(mapStateToProps)(
     Channels
 )

--- a/client/src/components/Labels.tsx
+++ b/client/src/components/Labels.tsx
@@ -6,12 +6,12 @@ import { connect } from 'react-redux'
 import {
     SettingsActionTypes,
 } from '../../../shared/src/actions/settingsActions'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
 import {
     SOCKET_FLUSH_LABELS,
     SOCKET_SET_LABELS,
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
-import { ICustomPages } from '../../../shared/src/reducers/settingsReducer'
+import { CustomPages } from '../../../shared/src/reducers/settingsReducer'
 import { getChannelLabel } from '../utils/labels'
 import {
     FaderActionTypes,
@@ -20,13 +20,13 @@ import {
     ChannelActionTypes,
 } from '../../../shared/src/actions/channelActions'
 
-interface ILabelSettingsInjectProps {
-    customPages: ICustomPages[]
-    fader: IFader[]
+interface LabelSettingsInjectProps {
+    customPages: CustomPages[]
+    fader: Fader[]
 }
 
 class LabelSettings extends React.PureComponent<
-    ILabelSettingsInjectProps & Store
+    LabelSettingsInjectProps & Store
 > {
     state = {
         mutations: {} as Record<string, string>,
@@ -102,7 +102,7 @@ class LabelSettings extends React.PureComponent<
     renderLabelList() {
         return (
             <div>
-                {this.props.fader.map((fader: IFader, index: number) => {
+                {this.props.fader.map((fader: Fader, index: number) => {
                     const faderLabel = fader.label || '-'
                     const channelLabel =
                         getChannelLabel(window.reduxState, index) || '-'
@@ -173,13 +173,13 @@ class LabelSettings extends React.PureComponent<
     }
 }
 
-const mapStateToProps = (state: any, props: any): ILabelSettingsInjectProps => {
+const mapStateToProps = (state: any, props: any): LabelSettingsInjectProps => {
     return {
         customPages: state.settings[0].customPages,
         fader: state.faders[0].fader,
     }
 }
 
-export default connect<any, ILabelSettingsInjectProps>(mapStateToProps)(
+export default connect<any, LabelSettingsInjectProps>(mapStateToProps)(
     LabelSettings
 ) as any

--- a/client/src/components/MicTally.tsx
+++ b/client/src/components/MicTally.tsx
@@ -3,9 +3,9 @@ import { connect } from 'react-redux'
 
 import '../assets/css/MicTally.css'
 import { Store } from 'redux'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
-import { IChannels } from '../../../shared/src/reducers/channelsReducer'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
+import { Channels } from '../../../shared/src/reducers/channelsReducer'
+import { Settings } from '../../../shared/src/reducers/settingsReducer'
 import { getFaderLabel } from '../utils/labels'
 
 import {
@@ -14,17 +14,17 @@ import {
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 
 
-interface IMicTallyInjectProps {
-    channels: IChannels
-    faders: IFader[]
-    settings: ISettings
+interface MicTallyInjectProps {
+    channels: Channels
+    faders: Fader[]
+    settings: Settings
 }
 
-interface IMicTallyState {
+interface MicTallyState {
     toggleTargetIndex: number | null
 }
 
-class MicTally extends React.Component<IMicTallyInjectProps & Store, IMicTallyState> {
+class MicTally extends React.Component<MicTallyInjectProps & Store, MicTallyState> {
     constructor(props: any) {
         super(props)
         this.props.settings.showMonitorOptions = -1
@@ -111,7 +111,7 @@ class MicTally extends React.Component<IMicTallyInjectProps & Store, IMicTallySt
     }
 }
 
-const mapStateToProps = (state: any): IMicTallyInjectProps => {
+const mapStateToProps = (state: any): MicTallyInjectProps => {
     return {
         channels: state.channels[0].chMixerConnection[0].channel,
         faders: state.faders[0].fader,
@@ -119,6 +119,6 @@ const mapStateToProps = (state: any): IMicTallyInjectProps => {
     }
 }
 
-export default connect<IMicTallyInjectProps, any, any>(mapStateToProps)(
+export default connect<MicTallyInjectProps, any, any>(mapStateToProps)(
     MicTally
 )

--- a/client/src/components/MiniChanStrip.tsx
+++ b/client/src/components/MiniChanStrip.tsx
@@ -4,26 +4,26 @@ import ReactSlider from 'react-slider'
 import '../assets/css/MiniChanStrip.css'
 import { Store } from 'redux'
 import { connect } from 'react-redux'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
 import { SOCKET_SET_AUX_LEVEL } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 import { getFaderLabel } from '../utils/labels'
 
-interface IChanStripInjectProps {
+interface ChanStripInjectProps {
     label: string
     selectedProtocol: string
     numberOfChannelsInType: Array<number>
     channel: Array<any>
-    fader: Array<IFader>
+    fader: Array<Fader>
     auxSendIndex: number
     offtubeMode: boolean
 }
 
-interface IChanStripProps {
+interface ChanStripProps {
     faderIndex: number
 }
 
 class MiniChanStrip extends React.PureComponent<
-    IChanStripProps & IChanStripInjectProps & Store
+    ChanStripProps & ChanStripInjectProps & Store
 > {
     constructor(props: any) {
         super(props)
@@ -96,8 +96,8 @@ class MiniChanStrip extends React.PureComponent<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IChanStripInjectProps => {
-    let inject: IChanStripInjectProps = {
+const mapStateToProps = (state: any, props: any): ChanStripInjectProps => {
+    let inject: ChanStripInjectProps = {
         label: '',
         selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
         numberOfChannelsInType:
@@ -122,6 +122,6 @@ const mapStateToProps = (state: any, props: any): IChanStripInjectProps => {
     return inject
 }
 
-export default connect<any, IChanStripInjectProps>(mapStateToProps)(
+export default connect<any, ChanStripInjectProps>(mapStateToProps)(
     MiniChanStrip
 ) as any

--- a/client/src/components/MiniChannel.tsx
+++ b/client/src/components/MiniChannel.tsx
@@ -6,27 +6,27 @@ import '../assets/css/NoUiSlider.css'
 
 //assets:
 import '../assets/css/MiniChannel.css'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
-import { IChannels } from '../../../shared/src/reducers/channelsReducer'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
+import { Channels } from '../../../shared/src/reducers/channelsReducer'
+import { Settings } from '../../../shared/src/reducers/settingsReducer'
 import { SettingsActionTypes } from '../../../shared/src/actions/settingsActions'
 import { getFaderLabel } from '../utils/labels'
 
-interface IChannelInjectProps {
-    channels: IChannels
-    fader: IFader
-    settings: ISettings
+interface ChannelInjectProps {
+    channels: Channels
+    fader: Fader
+    settings: Settings
     channelType: number
     channelTypeIndex: number
     label: string
 }
 
-interface IChannelProps {
+interface ChannelProps {
     faderIndex: number
 }
 
 class MiniChannel extends React.Component<
-    IChannelProps & IChannelInjectProps & Store
+    ChannelProps & ChannelInjectProps & Store
 > {
     faderIndex: number
 
@@ -35,7 +35,7 @@ class MiniChannel extends React.Component<
         this.faderIndex = this.props.faderIndex
     }
 
-    public shouldComponentUpdate(nextProps: IChannelInjectProps) {
+    public shouldComponentUpdate(nextProps: ChannelInjectProps) {
         return (
             nextProps.fader.showChannel != this.props.fader.showChannel ||
             nextProps.label != this.props.label ||
@@ -80,7 +80,7 @@ class MiniChannel extends React.Component<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IChannelInjectProps => {
+const mapStateToProps = (state: any, props: any): ChannelInjectProps => {
     return {
         channels: state.channels[0].chMixerConnection[0].channel,
         fader: state.faders[0].fader[props.faderIndex],
@@ -92,6 +92,6 @@ const mapStateToProps = (state: any, props: any): IChannelInjectProps => {
     }
 }
 
-export default connect<any, IChannelInjectProps, any>(mapStateToProps)(
+export default connect<any, ChannelInjectProps, any>(mapStateToProps)(
     MiniChannel
 ) as any

--- a/client/src/components/MiniChannels.tsx
+++ b/client/src/components/MiniChannels.tsx
@@ -3,25 +3,25 @@ import { connect } from 'react-redux'
 
 import '../assets/css/MiniChannels.css'
 import { Store } from 'redux'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
-import { IChannels } from '../../../shared/src/reducers/channelsReducer'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
+import { Channels as ChannelsInterface } from '../../../shared/src/reducers/channelsReducer'
+import { Settings } from '../../../shared/src/reducers/settingsReducer'
 import MiniChannel from './MiniChannel'
 import MiniChanStrip from './MiniChanStrip'
 
-interface IChannelsInjectProps {
-    channels: IChannels
-    faders: IFader[]
-    settings: ISettings
+interface ChannelsInjectProps {
+    channels: ChannelsInterface
+    faders: Fader[]
+    settings: Settings
 }
 
-class Channels extends React.Component<IChannelsInjectProps & Store> {
+class Channels extends React.Component<ChannelsInjectProps & Store> {
     constructor(props: any) {
         super(props)
         this.props.settings.showMonitorOptions = -1
     }
 
-    public shouldComponentUpdate(nextProps: IChannelsInjectProps) {
+    public shouldComponentUpdate(nextProps: ChannelsInjectProps) {
         return (
             this.props.settings.showOptions !==
                 nextProps.settings.showOptions ||
@@ -38,7 +38,7 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
     render() {
         return (
             <div className="mini-channels-body">
-                {this.props.faders.map((fader: IFader, index: number) => {
+                {this.props.faders.map((fader: Fader, index: number) => {
                     return fader.showInMiniMonitor ? (
                         <MiniChannel faderIndex={index} key={index} />
                     ) : null
@@ -61,7 +61,7 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
     }
 }
 
-const mapStateToProps = (state: any): IChannelsInjectProps => {
+const mapStateToProps = (state: any): ChannelsInjectProps => {
     return {
         channels: state.channels[0].chMixerConnection[0].channel,
         faders: state.faders[0].fader,
@@ -69,6 +69,6 @@ const mapStateToProps = (state: any): IChannelsInjectProps => {
     }
 }
 
-export default connect<IChannelsInjectProps, any, any>(mapStateToProps)(
+export default connect<ChannelsInjectProps, any, any>(mapStateToProps)(
     Channels
 )

--- a/client/src/components/PagesSettings.tsx
+++ b/client/src/components/PagesSettings.tsx
@@ -7,13 +7,13 @@ import { connect } from 'react-redux'
 import {
     SettingsActionTypes,
 } from '../../../shared/src/actions/settingsActions'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
 import Select from 'react-select'
 import {
     SOCKET_GET_PAGES_LIST,
     SOCKET_SET_PAGES_LIST,
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
-import { ICustomPages } from '../../../shared/src/reducers/settingsReducer'
+import { CustomPages } from '../../../shared/src/reducers/settingsReducer'
 import { getFaderLabel } from '../utils/labels'
 
 //Set style for Select dropdown component:
@@ -33,13 +33,13 @@ const selectorColorStyles = {
     },
     singleValue: (styles: any) => ({ ...styles, color: 'white' }),
 }
-interface IPagesSettingsInjectProps {
-    customPages: ICustomPages[]
-    fader: IFader[]
+interface PagesSettingsInjectProps {
+    customPages: CustomPages[]
+    fader: Fader[]
 }
 
 class PagesSettings extends React.PureComponent<
-    IPagesSettingsInjectProps & Store
+    PagesSettingsInjectProps & Store
 > {
     pageList: { label: string; value: number }[]
     state = { pageIndex: 0, label: '' }
@@ -48,7 +48,7 @@ class PagesSettings extends React.PureComponent<
         super(props)
 
         this.pageList = this.props.customPages.map(
-            (page: ICustomPages, index: number) => {
+            (page: CustomPages, index: number) => {
                 return { label: page.label, value: index }
             }
         )
@@ -77,7 +77,7 @@ class PagesSettings extends React.PureComponent<
                         String(this.state.pageIndex + 1)
                 )
             ) {
-                let nextPages: ICustomPages[] = [...this.props.customPages]
+                let nextPages: CustomPages[] = [...this.props.customPages]
                 nextPages[this.state.pageIndex].faders.splice(
                     this.props.customPages[this.state.pageIndex].faders.indexOf(
                         fader
@@ -98,7 +98,7 @@ class PagesSettings extends React.PureComponent<
                         '?'
                 )
             ) {
-                let nextPages: ICustomPages[] = [...this.props.customPages]
+                let nextPages: CustomPages[] = [...this.props.customPages]
                 nextPages[this.state.pageIndex].faders.push(fader)
                 nextPages[this.state.pageIndex].faders.sort((a, b) => {
                     return a - b
@@ -112,7 +112,7 @@ class PagesSettings extends React.PureComponent<
     handleLabel = (event: ChangeEvent<HTMLInputElement>) => {
         this.setState({ label: event.target.value })
         this.pageList[this.state.pageIndex].label = event.target.value
-        let nextPages: ICustomPages[] = [...this.props.customPages]
+        let nextPages: CustomPages[] = [...this.props.customPages]
         nextPages[this.state.pageIndex].label = event.target.value
 
         window.storeRedux.dispatch({ type: SettingsActionTypes.SET_PAGES_LIST, customPages: nextPages})
@@ -121,7 +121,7 @@ class PagesSettings extends React.PureComponent<
 
     handleClearRouting() {
         if (window.confirm('REMOVE ALL FADER ASSIGNMENTS????')) {
-            let nextPages: ICustomPages[] = [...this.props.customPages]
+            let nextPages: CustomPages[] = [...this.props.customPages]
             nextPages[this.state.pageIndex].faders = []
             window.storeRedux.dispatch({ type: SettingsActionTypes.SET_PAGES_LIST, customPages: nextPages})
             window.socketIoClient.emit(SOCKET_SET_PAGES_LIST, nextPages)
@@ -136,7 +136,7 @@ class PagesSettings extends React.PureComponent<
     renderFaderList() {
         return (
             <div>
-                {this.props.fader.map((fader: IFader, index: number) => {
+                {this.props.fader.map((fader: Fader, index: number) => {
                     return (
                         <div
                             key={index}
@@ -208,13 +208,13 @@ class PagesSettings extends React.PureComponent<
     }
 }
 
-const mapStateToProps = (state: any, props: any): IPagesSettingsInjectProps => {
+const mapStateToProps = (state: any, props: any): PagesSettingsInjectProps => {
     return {
         customPages: state.settings[0].customPages,
         fader: state.faders[0].fader,
     }
 }
 
-export default connect<any, IPagesSettingsInjectProps>(mapStateToProps)(
+export default connect<any, PagesSettingsInjectProps>(mapStateToProps)(
     PagesSettings
 ) as any

--- a/client/src/components/ReductionMeter.tsx
+++ b/client/src/components/ReductionMeter.tsx
@@ -5,15 +5,15 @@ import { connect } from 'react-redux'
 import '../assets/css/ReductionMeter.css'
 //Utils:
 
-export interface IReductionMeterInjectedProps {
+export interface ReductionMeterInjectedProps {
     reductionVal: number
 }
 
-interface IVuMeterProps {
+interface VuMeterProps {
     faderIndex: number
 }
 
-export class ReductionMeter extends React.Component<IReductionMeterInjectedProps> {
+export class ReductionMeter extends React.Component<ReductionMeterInjectedProps> {
     canvas: HTMLCanvasElement | undefined
 
     totalPeak: number = 0
@@ -33,7 +33,7 @@ export class ReductionMeter extends React.Component<IReductionMeterInjectedProps
         this.meterZero = window.mixerProtocol.meter?.zero || 0.75
     }
 
-    public shouldComponentUpdate(nextProps: IReductionMeterInjectedProps) {
+    public shouldComponentUpdate(nextProps: ReductionMeterInjectedProps) {
         return nextProps.reductionVal != this.props.reductionVal
     }
 
@@ -183,12 +183,12 @@ export class ReductionMeter extends React.Component<IReductionMeterInjectedProps
 const mapStateToProps = (
     state: any,
     props: any
-): IReductionMeterInjectedProps => {
+): ReductionMeterInjectedProps => {
     return {
         reductionVal: state.faders[0].vuMeters[props.faderIndex].reductionVal,
     }
 }
 
-export default connect<IReductionMeterInjectedProps, any, any>(mapStateToProps)(
+export default connect<ReductionMeterInjectedProps, any, any>(mapStateToProps)(
     ReductionMeter
 )

--- a/client/src/components/RoutingStorage.tsx
+++ b/client/src/components/RoutingStorage.tsx
@@ -14,11 +14,11 @@ import {
     SOCKET_LOAD_MIXER_PRESET,
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 
-interface IStorageProps {
+interface StorageProps {
     load: any
     save: any
 }
-class Storage extends React.PureComponent<IStorageProps & Store> {
+class Storage extends React.PureComponent<StorageProps & Store> {
     fileList: string[] = []
     loadSnapshot: any
     saveSnapshot: any

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -2,17 +2,16 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 import Select from 'react-select'
 import WebMidi from 'webmidi'
-import { IAppProps } from './App'
+import { AppProps } from './App'
 
 //Utils:
 import '../assets/css/Settings.css'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
+import { Settings as SettingsInterface } from '../../../shared/src/reducers/settingsReducer'
 import { Store } from 'redux'
 import { ChangeEvent } from 'react'
 import { SOCKET_SAVE_SETTINGS } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 import {
     SettingsActionTypes,
-    SettingsActions,
 } from '../../../shared/src/actions/settingsActions'
 import { MixerConnectionTypes } from '../../../shared/src/constants/MixerProtocolInterface'
 
@@ -35,11 +34,11 @@ const selectorColorStyles = {
     singleValue: (styles: any) => ({ ...styles, color: 'white' }),
 }
 
-interface IState {
-    settings: ISettings
+interface SettingsState {
+    settings: SettingsInterface
 }
 
-class Settings extends React.PureComponent<IAppProps & Store, IState> {
+class Settings extends React.PureComponent<AppProps & Store, SettingsState> {
     selectedProtocol: any
     midiInputPortList: any
     midiOutputPortList: any
@@ -575,7 +574,7 @@ class Settings extends React.PureComponent<IAppProps & Store, IState> {
     }
 }
 
-const mapStateToProps = (state: any, t: any): IAppProps => {
+const mapStateToProps = (state: any, t: any): AppProps => {
     return {
         store: state,
         t: t,

--- a/client/src/components/VuMeter.tsx
+++ b/client/src/components/VuMeter.tsx
@@ -6,16 +6,16 @@ import { vuMeters } from '../utils/SocketClientHandlers'
 import '../assets/css/VuMeter.css'
 //Utils:
 
-export interface IVuMeterInjectedProps {
+export interface VuMeterInjectedProps {
     faderIndex: number
     channel: number
 }
 
-interface IVuMeterProps {
+interface VuMeterProps {
     faderIndex: number
 }
 
-export class VuMeter extends React.PureComponent<IVuMeterInjectedProps> {
+export class VuMeter extends React.PureComponent<VuMeterInjectedProps> {
     canvas: HTMLCanvasElement | undefined
 
     totalPeak: number = 0
@@ -217,13 +217,13 @@ export class VuMeter extends React.PureComponent<IVuMeterInjectedProps> {
     }
 }
 
-const mapStateToProps = (state: any, props: any): IVuMeterInjectedProps => {
+const mapStateToProps = (state: any, props: any): VuMeterInjectedProps => {
     return {
         faderIndex: props.faderIndex,
         channel: props.channel
     }
 }
 
-export default connect<IVuMeterInjectedProps, any, any>(mapStateToProps)(
+export default connect<VuMeterInjectedProps, any, any>(mapStateToProps)(
     VuMeter
 )

--- a/client/src/utils/SocketClientHandlers.ts
+++ b/client/src/utils/SocketClientHandlers.ts
@@ -18,11 +18,11 @@ import {
     SOCKET_RETURN_PAGES_LIST,
 } from '../../../shared/src/constants/SOCKET_IO_DISPATCHERS'
 import {
-    IchMixerConnection,
-    InumberOfChannels,
+    ChMixerConnection,
+    NumberOfChannels,
 } from '../../../shared/src/reducers/channelsReducer'
 import { VuType } from '../../../shared/src/utils/vu-server-types'
-import { IMixerSettings } from '../../../shared/src/reducers/settingsReducer'
+import { MixerSettings } from '../../../shared/src/reducers/settingsReducer'
 
 export const vuMeters: number[][] = []
 
@@ -52,10 +52,10 @@ export const socketClientHandlers = () => {
         .on(SOCKET_SET_FULL_STORE, (payload: any) => {
             // console.log('STATE RECEIVED :', payload)
             if (window.mixerProtocol) {
-                let numberOfChannels: InumberOfChannels[] = []
+                let numberOfChannels: NumberOfChannels[] = []
                 payload.channels[0].chMixerConnection.forEach(
                     (
-                        chMixerConnection: IchMixerConnection,
+                        chMixerConnection: ChMixerConnection,
                         mixerIndex: number
                     ) => {
                         numberOfChannels.push({ numberOfTypeInCh: [] })
@@ -75,7 +75,7 @@ export const socketClientHandlers = () => {
                     numberOfFaders: payload.settings[0].numberOfFaders,
                 })
                 payload.settings[0].mixers.forEach(
-                    (mixer: IMixerSettings, i: number) => {
+                    (mixer: MixerSettings, i: number) => {
                         window.storeRedux.dispatch({
                             type: SettingsActionTypes.SET_MIXER_ONLINE,
                             mixerIndex: i,

--- a/client/src/utils/labels.ts
+++ b/client/src/utils/labels.ts
@@ -1,7 +1,7 @@
-import { IStore } from '../../../shared/src/reducers/store'
+import { ReduxStore } from '../../../shared/src/reducers/store'
 
 export function getChannelLabel(
-    state: IStore,
+    state: ReduxStore,
     faderIndex: number
 ): string | undefined {
     return state.channels[0].chMixerConnection
@@ -16,7 +16,7 @@ export function getChannelLabel(
 }
 
 export function getFaderLabel(faderIndex: number, defaultName = 'CH'): string {
-    const state: IStore = window.reduxState
+    const state: ReduxStore = window.reduxState
     const automationLabel =
         state.faders[0].fader[faderIndex] &&
         state.faders[0].fader[faderIndex].label !== ''

--- a/server/src/MainThreadHandler.ts
+++ b/server/src/MainThreadHandler.ts
@@ -32,11 +32,11 @@ import {
     ChannelActionTypes,
 } from '../../shared/src/actions/channelActions'
 import { logger } from './utils/logger'
-import { ICustomPages } from '../../shared/src/reducers/settingsReducer'
+import { CustomPages } from '../../shared/src/reducers/settingsReducer'
 import { fxParamsList } from '../../shared/src/constants/MixerProtocolInterface'
 import path from 'path'
-import { IChannel } from '../../shared/src/reducers/channelsReducer'
-import { IChannelReference } from '../../shared/src/reducers/fadersReducer'
+import { Channel } from '../../shared/src/reducers/channelsReducer'
+import { ChannelReference } from '../../shared/src/reducers/fadersReducer'
 
 export class MainThreadHandlers {
     snapshotHandler: SnapshotHandler
@@ -66,7 +66,7 @@ export class MainThreadHandlers {
             state: state.faders[0].fader[faderIndex],
         })
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (channel: IChannelReference) => {
+            (channel: ChannelReference) => {
                 socketServer.emit(IO.SOCKET_SET_STORE_CHANNEL, {
                     channelIndex: channel.channelIndex,
                     state: state.channels[0].chMixerConnection[
@@ -87,12 +87,12 @@ export class MainThreadHandlers {
 
     reIndexAssignedChannelsRelation() {
         state.channels[0].chMixerConnection.forEach((mixer: any) => {
-            mixer.channel.forEach((channel: IChannel) => {
+            mixer.channel.forEach((channel: Channel) => {
                 channel.assignedFader = -1
             })
         })
         state.faders[0].fader.forEach((fader, faderIndex) => {
-            fader.assignedChannels?.forEach((channel: IChannelReference) => {
+            fader.assignedChannels?.forEach((channel: ChannelReference) => {
                 store.dispatch({
                     type: ChannelActionTypes.SET_ASSIGNED_FADER,
                     mixerIndex: channel.mixerIndex,
@@ -105,7 +105,7 @@ export class MainThreadHandlers {
 
     cleanUpAssignedChannelsOnFaders() {
         state.faders[0].fader.forEach((fader, faderIndex) => {
-            fader.assignedChannels?.forEach((channel: IChannelReference) => {
+            fader.assignedChannels?.forEach((channel: ChannelReference) => {
                 if (state.settings[0].numberOfMixers < channel.mixerIndex + 1) {
                     store.dispatch({
                         type: ChannelActionTypes.SET_ASSIGNED_FADER,
@@ -197,7 +197,7 @@ export class MainThreadHandlers {
             })
             .on(IO.SOCKET_GET_PAGES_LIST, () => {
                 logger.info('Get custom pages list')
-                let customPages: ICustomPages[] = getCustomPages()
+                let customPages: CustomPages[] = getCustomPages()
                 if (
                     customPages.length === state.settings[0].numberOfCustomPages
                 ) {

--- a/server/src/utils/AutomationConnection.ts
+++ b/server/src/utils/AutomationConnection.ts
@@ -5,10 +5,10 @@ import { mixerGenericConnection } from '../mainClasses'
 
 //Utils:
 import {
-    IAutomationProtocol,
+    AutomationProtocol,
     AutomationPresets,
 } from '../../../shared/src/constants/AutomationPresets'
-import { IFader } from '../../../shared/src/reducers/fadersReducer'
+import { Fader } from '../../../shared/src/reducers/fadersReducer'
 import {
     FaderActionTypes,
     FaderActions,
@@ -19,7 +19,7 @@ import { logger } from './logger'
 const AUTOMATION_OSC_PORT = 5255
 export class AutomationConnection {
     oscConnection: any
-    automationProtocol: IAutomationProtocol
+    automationProtocol: AutomationProtocol
 
     constructor() {
         this.sendOutMessage = this.sendOutMessage.bind(this)
@@ -39,7 +39,7 @@ export class AutomationConnection {
             timetag: number | undefined,
             info: any
         ) => {
-            const check = (key: keyof IAutomationProtocol['fromAutomation']) =>
+            const check = (key: keyof AutomationProtocol['fromAutomation']) =>
                 this.checkOscCommand(
                     message.address,
                     this.automationProtocol.fromAutomation[key]
@@ -245,7 +245,7 @@ export class AutomationConnection {
                                     voOn,
                                     pstOn,
                                     showChannel,
-                                }: IFader,
+                                }: Fader,
                                 index
                             ) => ({
                                 faderLevel,

--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -5,9 +5,9 @@ import { remoteConnections } from '../mainClasses'
 //Utils:
 import {  MixerProtocolPresets } from '../../../shared/src/constants/MixerProtocolPresets'
 import {
-    IMixerProtocol,
-    IMixerProtocolGeneric,
-    ICasparCGMixerGeometry,
+    MixerProtocol,
+    MixerProtocolGeneric,
+    CasparCGMixerGeometry,
     fxParamsList,
     MixerConnectionTypes
 } from '../../../shared/src/constants/MixerProtocolInterface'
@@ -21,7 +21,7 @@ import { LawoRubyMixerConnection } from './mixerConnections/LawoRubyConnection'
 import { StuderMixerConnection } from './mixerConnections/StuderMixerConnection'
 import { StuderVistaMixerConnection } from './mixerConnections/StuderVistaMixerConnection'
 import { CasparCGConnection } from './mixerConnections/CasparCGConnection'
-import { IchMixerConnection } from '../../../shared/src/reducers/channelsReducer'
+import { ChMixerConnection } from '../../../shared/src/reducers/channelsReducer'
 import {
     ChannelActionTypes,
 } from '../../../shared/src/actions/channelActions'
@@ -29,10 +29,10 @@ import {
     FaderActionTypes,
 } from '../../../shared/src/actions/faderActions'
 import { AtemMixerConnection } from './mixerConnections/AtemConnection'
-import { IChannelReference } from '../../../shared/src/reducers/fadersReducer'
+import { ChannelReference } from '../../../shared/src/reducers/fadersReducer'
 
 export class MixerGenericConnection {
-    mixerProtocol: IMixerProtocolGeneric[]
+    mixerProtocol: MixerProtocolGeneric[]
     mixerConnection: Array<
         | OscMixerConnection
         | QlClMixerConnection
@@ -64,49 +64,49 @@ export class MixerGenericConnection {
             switch (this.mixerProtocol[index].protocol) {
                 case MixerConnectionTypes.OSC: {
                     this.mixerConnection[index] = new OscMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.YamahaQlCl: {
                     this.mixerConnection[index] = new QlClMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.GenericMidi: {
                     this.mixerConnection[index] = new MidiMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.CasparCG: {
                     this.mixerConnection[index] = new CasparCGConnection(
-                        this.mixerProtocol[index] as ICasparCGMixerGeometry,
+                        this.mixerProtocol[index] as CasparCGMixerGeometry,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.EMBER: {
                     this.mixerConnection[index] = new EmberMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.LawoRuby: {
                     this.mixerConnection[index] = new LawoRubyMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.Studer: {
                     this.mixerConnection[index] = new StuderMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
@@ -114,21 +114,21 @@ export class MixerGenericConnection {
                 case MixerConnectionTypes.StuderVista: {
                     this.mixerConnection[index] =
                         new StuderVistaMixerConnection(
-                            this.mixerProtocol[index] as IMixerProtocol,
+                            this.mixerProtocol[index] as MixerProtocol,
                             index
                         )
                         break
                     }
                 case MixerConnectionTypes.SSLSystemT: {
                     this.mixerConnection[index] = new SSLMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
                 }
                 case MixerConnectionTypes.vMix: {
                     this.mixerConnection[index] = new VMixMixerConnection(
-                        this.mixerProtocol[index] as IMixerProtocol,
+                        this.mixerProtocol[index] as MixerProtocol,
                         index
                     )
                     break
@@ -154,7 +154,7 @@ export class MixerGenericConnection {
         // Setup timers for fade in & out
         this.mixerTimers = []
         state.channels[0].chMixerConnection.forEach(
-            (chMixerConnection: IchMixerConnection, mixerIndex: number) => {
+            (chMixerConnection: ChMixerConnection, mixerIndex: number) => {
                 this.mixerTimers.push({ chTimer: [], fadeActiveTimer: [] })
                 state.channels[0].chMixerConnection[mixerIndex].channel.forEach(
                     (channel) => {
@@ -246,7 +246,7 @@ export class MixerGenericConnection {
         }
 
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 if (assignedChannel.mixerIndex !== mixerIndexToSkip) {
                     this.fadeInOut(
                         assignedChannel.mixerIndex,
@@ -269,7 +269,7 @@ export class MixerGenericConnection {
     updateInputGain = (faderIndex: number) => {
         let level = state.faders[0].fader[faderIndex].inputGain
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 this.mixerConnection[
                     assignedChannel.mixerIndex
                 ].updateInputGain(assignedChannel.channelIndex, level)
@@ -281,7 +281,7 @@ export class MixerGenericConnection {
         let inputSelected = state.faders[0].fader[faderIndex].inputSelector
         logger.trace(`${faderIndex} ${inputSelected}`)
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 this.mixerConnection[
                     assignedChannel.mixerIndex
                 ].updateInputSelector(
@@ -298,7 +298,7 @@ export class MixerGenericConnection {
 
     updateMuteState = (faderIndex: number, mixerIndexToSkip: number = -1) => {
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 if (assignedChannel.mixerIndex !== mixerIndexToSkip) {
                     this.mixerConnection[
                         assignedChannel.mixerIndex
@@ -313,7 +313,7 @@ export class MixerGenericConnection {
 
     updateAMixState = (faderIndex: number) => {
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 this.mixerConnection[
                     assignedChannel.mixerIndex
                 ].updateAMixState(
@@ -335,7 +335,7 @@ export class MixerGenericConnection {
                 100
         }
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 this.mixerConnection[assignedChannel.mixerIndex].updateNextAux(
                     assignedChannel.channelIndex,
                     level
@@ -347,7 +347,7 @@ export class MixerGenericConnection {
     updateFx = (fxParam: fxParamsList, faderIndex: number) => {
         let level: number = state.faders[0].fader[faderIndex][fxParam][0]
         state.faders[0].fader[faderIndex].assignedChannels?.forEach(
-            (assignedChannel: IChannelReference) => {
+            (assignedChannel: ChannelReference) => {
                 this.mixerConnection[assignedChannel.mixerIndex].updateFx(
                     fxParam,
                     assignedChannel.channelIndex,

--- a/server/src/utils/SettingsStorage.ts
+++ b/server/src/utils/SettingsStorage.ts
@@ -15,20 +15,20 @@ import { logger } from './logger'
 import { defaultFadersReducerState } from '../../../shared/src/reducers/fadersReducer'
 
 import {
-    IChannels,
-    InumberOfChannels,
+    Channels,
+    NumberOfChannels,
     defaultChannelsReducerState,
 } from '../../../shared/src/reducers/channelsReducer'
 
 import {
-    ICustomPages,
-    ISettings,
+    CustomPages,
+    Settings,
 } from '../../../shared/src/reducers/settingsReducer'
-import { IFaders } from '../../../shared/src/reducers/fadersReducer'
+import { Faders } from '../../../shared/src/reducers/fadersReducer'
 
-export interface IShotStorage {
-    channelState: IChannels
-    faderState: IFaders
+export interface ShotStorage {
+    channelState: Channels
+    faderState: Faders
 }
 
 // Linux place in "app"/storage to be backward compatible with Docker containers.
@@ -38,7 +38,7 @@ export const STORAGE_FOLDER = (platform === 'linux') ?
     path.resolve(homeDir, 'sisyfos-storage')
 
 
-export const loadSettings = (storeRedux: any): ISettings => {
+export const loadSettings = (storeRedux: any): Settings => {
     let newSettings = storeRedux.settings[0]
     try {
         newSettings = JSON.parse(
@@ -78,13 +78,13 @@ export const saveSettings = (settings: any) => {
 }
 
 export const loadSnapshotState = (
-    numberOfChannels: InumberOfChannels[],
+    numberOfChannels: NumberOfChannels[],
     numberOfFaders: number,
     fileName: string,
     loadAll: boolean
 ) => {
     try {
-        const stateFromFile: IShotStorage = JSON.parse(
+        const stateFromFile: ShotStorage = JSON.parse(
             fs.readFileSync(fileName, 'utf8')
         )
 
@@ -92,12 +92,12 @@ export const loadSnapshotState = (
             store.dispatch({
                 type: ChannelActionTypes.SET_COMPLETE_CH_STATE,
                 numberOfTypeChannels: numberOfChannels,
-                allState: stateFromFile.channelState as IChannels,
+                allState: stateFromFile.channelState as Channels,
             })
             store.dispatch({
                 type: FaderActionTypes.SET_COMPLETE_FADER_STATE,
                 numberOfFaders: numberOfFaders,
-                allState: stateFromFile.faderState as IFaders,
+                allState: stateFromFile.faderState as Faders,
             })
         }
     } catch (error) {
@@ -188,7 +188,7 @@ export const setCcgDefault = (fileName: string) => {
     })
 }
 
-export const getCustomPages = (): ICustomPages[] => {
+export const getCustomPages = (): CustomPages[] => {
     try {
         return JSON.parse(
             fs.readFileSync(path.resolve(STORAGE_FOLDER, 'pages.json'), 'utf8')

--- a/server/src/utils/SnapshotHandler.ts
+++ b/server/src/utils/SnapshotHandler.ts
@@ -3,12 +3,12 @@ import { loadSnapshotState, saveSnapshotState } from './SettingsStorage'
 import { mixerProtocolPresets } from '../mainClasses'
 import { state } from '../reducers/store'
 import { logger } from './logger'
-import { InumberOfChannels } from '../../../shared/src/reducers/channelsReducer'
+import { NumberOfChannels } from '../../../shared/src/reducers/channelsReducer'
 import { STORAGE_FOLDER } from './SettingsStorage'
 
 import path from 'path'
 export class SnapshotHandler {
-    numberOfChannels: InumberOfChannels[] = []
+    numberOfChannels: NumberOfChannels[] = []
 
     constructor() {
         logger.info('Setting up state')

--- a/server/src/utils/labels.ts
+++ b/server/src/utils/labels.ts
@@ -1,8 +1,8 @@
-import { IchMixerConnection } from '../../../shared/src/reducers/channelsReducer'
+import { ChMixerConnection } from '../../../shared/src/reducers/channelsReducer'
 import { state } from '../reducers/store'
 
 export function getChannelLabel(
-    chMixerConnection: IchMixerConnection[],
+    chMixerConnection: ChMixerConnection[],
     faderIndex: number
 ): string | undefined {
     return chMixerConnection

--- a/server/src/utils/migrations.ts
+++ b/server/src/utils/migrations.ts
@@ -2,12 +2,12 @@ import fs from 'fs'
 import path from 'path'
 
 import { logger } from './logger'
-import { ISettings } from '../../../shared/src/reducers/settingsReducer'
-import { getSnapShotList, IShotStorage, STORAGE_FOLDER } from './SettingsStorage'
+import { Settings } from '../../../shared/src/reducers/settingsReducer'
+import { getSnapShotList, ShotStorage, STORAGE_FOLDER } from './SettingsStorage'
 
 const version = process.env.npm_package_version
 
-export const checkVersion = (currentSettings: ISettings): ISettings => {
+export const checkVersion = (currentSettings: Settings): Settings => {
     if (
         versionAsNumber(version) >
         versionAsNumber(currentSettings.sisyfosVersion)
@@ -17,7 +17,7 @@ export const checkVersion = (currentSettings: ISettings): ISettings => {
     return currentSettings
 }
 
-const migrateVersion = (currentSettings: ISettings): ISettings => {
+const migrateVersion = (currentSettings: Settings): Settings => {
     logger.info(
         `Migrating VERSION from ${currentSettings.sisyfosVersion} to ${version}`
     )
@@ -28,7 +28,7 @@ const migrateVersion = (currentSettings: ISettings): ISettings => {
     return newSettings
 }
 
-const migrate45to47 = (currentSettings: ISettings): ISettings => {
+const migrate45to47 = (currentSettings: Settings): Settings => {
     let files: string[] = getSnapShotList()
     files.push('default.shot')
 
@@ -50,7 +50,7 @@ const migrate45to47 = (currentSettings: ISettings): ISettings => {
                 ]
                 delete stateFromShot.channelState.channel
             }
-            let migratedShot: IShotStorage = stateFromShot
+            let migratedShot: ShotStorage = stateFromShot
             
             fs.writeFileSync(
                 path.join(STORAGE_FOLDER, fileName),

--- a/server/src/utils/mixerConnections/AtemConnection.ts
+++ b/server/src/utils/mixerConnections/AtemConnection.ts
@@ -3,15 +3,15 @@ import { Atem, AtemState } from 'atem-connection'
 import { store, state } from '../../reducers/store'
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import { logger } from '../logger'
 import { SettingsActionTypes } from '../../../../shared/src/actions/settingsActions'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
-import { IChannel } from '../../../../shared/src/reducers/channelsReducer'
+import { Channel } from '../../../../shared/src/reducers/channelsReducer'
 import { dbToFloat, floatToDB } from './LawoRubyConnection'
 import {
     FairlightAudioMixOption,
@@ -36,7 +36,7 @@ export class AtemMixerConnection {
     private _firstConnection = true
 
     constructor(
-        private mixerProtocol: IMixerProtocol,
+        private mixerProtocol: MixerProtocol,
         public mixerIndex: number
     ) {
         this._connection = new Atem()
@@ -319,10 +319,10 @@ export class AtemMixerConnection {
         }
     }
 
-    private getAssignedFader(channelIndex: number): IFader {
-        return state.faders[0].fader.find((fader: IFader) => {
+    private getAssignedFader(channelIndex: number): Fader {
+        return state.faders[0].fader.find((fader: Fader) => {
             return fader.assignedChannels?.some(
-                (assignedChannel: IChannelReference) => {
+                (assignedChannel: ChannelReference) => {
                     return (
                         assignedChannel.mixerIndex === this.mixerIndex &&
                         assignedChannel.channelIndex === channelIndex
@@ -332,7 +332,7 @@ export class AtemMixerConnection {
         })
     }
 
-    private getChannel(channelIndex: number): IChannel {
+    private getChannel(channelIndex: number): Channel {
         return state.channels[0].chMixerConnection[this.mixerIndex].channel[
             channelIndex
         ]
@@ -340,8 +340,8 @@ export class AtemMixerConnection {
 
     private setPropsFromChannel(
         channelIndex: number,
-        channel: IChannel,
-        fader: IFader,
+        channel: Channel,
+        fader: Fader,
         source: FairlightAudioSource
     ) {
         if ((source.properties.gain + 1200) / 1800 !== fader.inputGain) {

--- a/server/src/utils/mixerConnections/EmberMixerConnection.ts
+++ b/server/src/utils/mixerConnections/EmberMixerConnection.ts
@@ -7,7 +7,7 @@ import fs from 'fs'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     FaderActionTypes,
@@ -22,21 +22,21 @@ import {
     SettingsActionTypes,
 } from '../../../../shared/src/actions/settingsActions'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
 import { EmberElement, NumberedTreeNode } from 'emberplus-connection/dist/model'
 import { STORAGE_FOLDER } from '../SettingsStorage'
 
 export class EmberMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     emberConnection: EmberClient
     deviceRoot: any
     emberNodeObject: Array<any>
     isSubscribedToChannel: Array<boolean> = []
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
@@ -48,8 +48,8 @@ export class EmberMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number) {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex

--- a/server/src/utils/mixerConnections/LawoRubyConnection.ts
+++ b/server/src/utils/mixerConnections/LawoRubyConnection.ts
@@ -5,7 +5,7 @@ import { remoteConnections } from '../../mainClasses'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     FaderActionTypes,
@@ -47,12 +47,12 @@ export function dbToFloat(d: number): number {
 }
 
 export class LawoRubyMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     emberConnection: EmberClient
     faders: { [index: number]: string } = {}
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 

--- a/server/src/utils/mixerConnections/MidiMixerConnection.ts
+++ b/server/src/utils/mixerConnections/MidiMixerConnection.ts
@@ -9,7 +9,7 @@ import { remoteConnections } from '../../mainClasses'
 import { MixerProtocolPresets } from '../../../../shared/src/constants/MixerProtocolPresets'
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     ChannelActionTypes,
@@ -19,8 +19,8 @@ import {
 } from '../../../../shared/src/actions/faderActions'
 import { logger } from '../logger'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
 
 export class MidiMixerConnection {
@@ -29,7 +29,7 @@ export class MidiMixerConnection {
     midiInput: any
     midiOutput: any
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
@@ -63,8 +63,8 @@ export class MidiMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number) {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex
@@ -118,7 +118,7 @@ export class MidiMixerConnection {
                     state.faders[0].fader[
                         faderChannel - 1
                     ].assignedChannels?.forEach(
-                        (channel: IChannelReference) => {
+                        (channel: ChannelReference) => {
                             if (channel.mixerIndex === this.mixerIndex) {
                                 this.updateOutLevel(
                                     channel.channelIndex,

--- a/server/src/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/src/utils/mixerConnections/OscMixerConnection.ts
@@ -9,7 +9,7 @@ import { mixerGenericConnection, remoteConnections } from '../../mainClasses'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import { behringerXrMeter } from './productSpecific/behringerXr'
 import { midasMeter } from './productSpecific/midas'
@@ -26,27 +26,27 @@ import { logger } from '../logger'
 import { sendVuLevel } from '../vuServer'
 import { VuType } from '../../../../shared/src/utils/vu-server-types'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
-import { IChannel } from '../../../../shared/src/reducers/channelsReducer'
+import { Channel } from '../../../../shared/src/reducers/channelsReducer'
 import { STORAGE_FOLDER } from '../SettingsStorage'
 
-interface IOscCommand {
+interface OscCommand {
     address: string
     args?: any[]
 }
 
 export class OscMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     cmdChannelIndex: number
     oscConnection: any
     mixerOnlineTimer: NodeJS.Timeout
     timeoutTimer: NodeJS.Timeout
-    commandBuffer: IOscCommand[] = []
+    commandBuffer: OscCommand[] = []
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
@@ -105,8 +105,8 @@ export class OscMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number): number {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex
@@ -214,7 +214,7 @@ export class OscMixerConnection {
                             state.faders[0].fader[
                                 assignedFaderIndex
                             ].assignedChannels?.forEach(
-                                (assignedChannel: IChannelReference) => {
+                                (assignedChannel: ChannelReference) => {
                                     if (
                                         assignedChannel.mixerIndex ===
                                         this.mixerIndex
@@ -255,7 +255,7 @@ export class OscMixerConnection {
                             state.faders[0].fader[
                                 assignedFaderIndex
                             ].assignedChannels?.forEach(
-                                (assignedChannel: IChannelReference) => {
+                                (assignedChannel: ChannelReference) => {
                                     if (
                                         assignedChannel.mixerIndex ===
                                         this.mixerIndex
@@ -416,7 +416,7 @@ export class OscMixerConnection {
                             state.channels[0].chMixerConnection[
                                 this.mixerIndex
                             ].channel.forEach(
-                                (channel: IChannel, index: number) => {
+                                (channel: Channel, index: number) => {
                                     const assignedFaderIndex =
                                         this.getAssignedFaderIndex(index)
                                     if (assignedFaderIndex >= 0) {
@@ -806,7 +806,7 @@ export class OscMixerConnection {
         }
     }
 
-    sendBuffered(command: IOscCommand) {
+    sendBuffered(command: OscCommand) {
         this.commandBuffer.push(JSON.parse(JSON.stringify(command)))
     }
 

--- a/server/src/utils/mixerConnections/SSLMixerConnection.ts
+++ b/server/src/utils/mixerConnections/SSLMixerConnection.ts
@@ -6,7 +6,7 @@ import { mixerGenericConnection, remoteConnections } from '../../mainClasses'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     ChannelActionTypes,
@@ -19,18 +19,18 @@ import {
 } from '../../../../shared/src/actions/settingsActions'
 import { logger } from '../logger'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
 
 export class SSLMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     cmdChannelIndex: number
     SSLConnection: any
     mixerOnlineTimer: any
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutLevelMessage = this.sendOutLevelMessage.bind(this)
 
         store.dispatch({
@@ -68,8 +68,8 @@ export class SSLMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number) {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex
@@ -117,7 +117,7 @@ export class SSLMixerConnection {
                             state.faders[0].fader[
                                 assignedFaderIndex
                             ].assignedChannels?.forEach(
-                                (item: IChannelReference) => {
+                                (item: ChannelReference) => {
                                     if (item.mixerIndex === this.mixerIndex) {
                                         this.updateOutLevel(item.channelIndex)
                                     }
@@ -136,7 +136,7 @@ export class SSLMixerConnection {
                     })
                     state.faders[0].fader[
                         assignedFaderIndex
-                    ].assignedChannels?.forEach((item: IChannelReference) => {
+                    ].assignedChannels?.forEach((item: ChannelReference) => {
                         if (item.mixerIndex === this.mixerIndex) {
                             store.dispatch({
                                 type: ChannelActionTypes.SET_OUTPUT_LEVEL,
@@ -190,7 +190,7 @@ export class SSLMixerConnection {
         }
 
         state.faders[0].fader[assignedFaderIndex].assignedChannels?.forEach(
-            (item: IChannelReference) => {
+            (item: ChannelReference) => {
                 if (
                     item.mixerIndex === this.mixerIndex &&
                     item.channelIndex !== channelIndex

--- a/server/src/utils/mixerConnections/StuderMixerConnection.ts
+++ b/server/src/utils/mixerConnections/StuderMixerConnection.ts
@@ -6,7 +6,7 @@ import { remoteConnections } from '../../mainClasses'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     FaderActionTypes,
@@ -17,13 +17,13 @@ import {
 } from '../../../../shared/src/actions/channelActions'
 
 export class StuderMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     emberConnection: any
     deviceRoot: any
     emberNodeObject: Array<any>
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 

--- a/server/src/utils/mixerConnections/StuderVistaMixerConnection.ts
+++ b/server/src/utils/mixerConnections/StuderVistaMixerConnection.ts
@@ -6,7 +6,7 @@ import net from 'net'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import { logger } from '../logger'
 import {
@@ -20,19 +20,19 @@ import {
 } from '../../../../shared/src/actions/channelActions'
 import { remoteConnections } from '../../mainClasses'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
-import { IChannel } from '../../../../shared/src/reducers/channelsReducer'
+import { Channel } from '../../../../shared/src/reducers/channelsReducer'
 
 export class StuderVistaMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     deviceRoot: any
     emberNodeObject: Array<any>
     mixerConnection: any
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
@@ -128,7 +128,7 @@ export class StuderVistaMixerConnection {
     findChannelInArray(channelType: number, channelTypeIndex: number): number {
         let channelArrayIndex = 0
         state.channels[0].chMixerConnection[this.mixerIndex].channel.forEach(
-            (channel: IChannel, index: number) => {
+            (channel: Channel, index: number) => {
                 if (
                     channel.channelType === channelType &&
                     channel.channelTypeIndex === channelTypeIndex
@@ -141,8 +141,8 @@ export class StuderVistaMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number) {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex
@@ -216,7 +216,7 @@ export class StuderVistaMixerConnection {
                 level: value,
             })
             state.faders[0].fader[assignedFaderIndex].assignedChannels?.forEach(
-                (assignedChannel: IChannelReference) => {
+                (assignedChannel: ChannelReference) => {
                     if (
                         assignedChannel.mixerIndex === this.mixerIndex &&
                         assignedChannel.channelIndex !== channelArrayIndex
@@ -395,9 +395,9 @@ export class StuderVistaMixerConnection {
     }
 
     pingChannel(mixerMessage: string) {
-        state.faders[0].fader.forEach((fader: IFader, index: number) => {
+        state.faders[0].fader.forEach((fader: Fader, index: number) => {
             fader.assignedChannels?.forEach(
-                (channelReference: IChannelReference) => {
+                (channelReference: ChannelReference) => {
                     if (channelReference.mixerIndex === this.mixerIndex) {
                         const channel =
                             state.channels[0].chMixerConnection[this.mixerIndex]

--- a/server/src/utils/mixerConnections/VMixMixerConnection.ts
+++ b/server/src/utils/mixerConnections/VMixMixerConnection.ts
@@ -6,7 +6,7 @@ import { XmlApi } from 'vmix-js-utils'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     ChannelActions,
@@ -25,12 +25,12 @@ import { sendVuLevel } from '../vuServer'
 import { VuType } from '../../../../shared/src/utils/vu-server-types'
 import { dbToFloat } from './LawoRubyConnection'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
 
 export class VMixMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     cmdChannelIndex: number
     vmixConnection: any
@@ -40,7 +40,7 @@ export class VMixMixerConnection {
     audioOn: Record<string, boolean> = {}
     lastLevel: Record<string, number> = {}
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
@@ -95,8 +95,8 @@ export class VMixMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number) {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex

--- a/server/src/utils/mixerConnections/YamahaQlClConnection.ts
+++ b/server/src/utils/mixerConnections/YamahaQlClConnection.ts
@@ -6,7 +6,7 @@ import { remoteConnections } from '../../mainClasses'
 //Utils:
 import {
     fxParamsList,
-    IMixerProtocol,
+    MixerProtocol,
 } from '../../../../shared/src/constants/MixerProtocolInterface'
 import {
     ChannelActionTypes,
@@ -21,18 +21,18 @@ import {
 import { sendVuLevel } from '../vuServer'
 import { VuType } from '../../../../shared/src/utils/vu-server-types'
 import {
-    IChannelReference,
-    IFader,
+    ChannelReference,
+    Fader,
 } from '../../../../shared/src/reducers/fadersReducer'
 
 export class QlClMixerConnection {
-    mixerProtocol: IMixerProtocol
+    mixerProtocol: MixerProtocol
     mixerIndex: number
     cmdChannelIndex: number
     midiConnection: any
     mixerOnlineTimer: any
 
-    constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
+    constructor(mixerProtocol: MixerProtocol, mixerIndex: number) {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
@@ -176,7 +176,7 @@ export class QlClMixerConnection {
                                 state.faders[0].fader[
                                     assignedFader - 1
                                 ].assignedChannels?.forEach(
-                                    (ch: IChannelReference) => {
+                                    (ch: ChannelReference) => {
                                         if (ch.mixerIndex === this.mixerIndex) {
                                             this.updateOutLevel(ch.channelIndex)
                                         }
@@ -221,7 +221,7 @@ export class QlClMixerConnection {
                         }
                         state.faders[0].fader[
                             assignedFaderIndex
-                        ].assignedChannels?.forEach((ch: IChannelReference) => {
+                        ].assignedChannels?.forEach((ch: ChannelReference) => {
                             if (ch.mixerIndex === this.mixerIndex) {
                                 this.updateMuteState(
                                     ch.channelIndex,
@@ -259,8 +259,8 @@ export class QlClMixerConnection {
     }
 
     private getAssignedFaderIndex(channelIndex: number) {
-        return state.faders[0].fader.findIndex((fader: IFader) =>
-            fader.assignedChannels?.some((assigned: IChannelReference) => {
+        return state.faders[0].fader.findIndex((fader: Fader) =>
+            fader.assignedChannels?.some((assigned: ChannelReference) => {
                 return (
                     assigned.mixerIndex === this.mixerIndex &&
                     assigned.channelIndex === channelIndex

--- a/server/src/utils/remoteConnections/HuiMidiRemoteConnection.ts
+++ b/server/src/utils/remoteConnections/HuiMidiRemoteConnection.ts
@@ -9,7 +9,7 @@ import {
 
 //Utils:
 import {
-    IRemoteProtocol,
+    RemoteProtocol,
     RemoteFaderPresets,
     MidiReceiveTypes,
 } from '../../../../shared/src/constants/remoteProtocols/HuiRemoteFaderPresets'
@@ -17,7 +17,7 @@ import { MixerProtocolPresets } from '../../../../shared/src/constants/MixerProt
 import { logger } from '../logger'
 
 export class HuiMidiRemoteConnection {
-    remoteProtocol: IRemoteProtocol
+    remoteProtocol: RemoteProtocol
     midiReceiveTypes = MidiReceiveTypes
     mixerProtocol: any
     midiInput: any

--- a/server/src/utils/remoteConnections/SkaarhojRemoteConnection.ts
+++ b/server/src/utils/remoteConnections/SkaarhojRemoteConnection.ts
@@ -7,7 +7,7 @@ import { FaderActionTypes } from '../../../../shared/src/actions/faderActions'
 
 //Utils:
 import {
-    IRemoteProtocol,
+    RemoteProtocol,
     RemoteFaderPresets,
 } from '../../../../shared/src/constants/remoteProtocols/SkaarhojProtocol'
 import { MixerProtocolPresets } from '../../../../shared/src/constants/MixerProtocolPresets'
@@ -15,7 +15,7 @@ import { logger } from '../logger'
 import { ChannelActionTypes } from '../../../../shared/src/actions/channelActions'
 
 export class SkaarhojRemoteConnection {
-    remoteProtocol: IRemoteProtocol
+    remoteProtocol: RemoteProtocol
     mixerProtocol: any
     clientList: any[]
 

--- a/shared/src/actions/channelActions.ts
+++ b/shared/src/actions/channelActions.ts
@@ -1,7 +1,7 @@
 import {
-  IChannel,
-  IChannels,
-  InumberOfChannels,
+  Channel,
+  Channels,
+  NumberOfChannels,
 } from '../reducers/channelsReducer'
 
 export enum ChannelActionTypes {
@@ -25,13 +25,13 @@ export type ChannelActions =
     }
   | {
         type: ChannelActionTypes.SET_COMPLETE_CH_STATE
-        numberOfTypeChannels: InumberOfChannels[]
-        allState: IChannels
+        numberOfTypeChannels: NumberOfChannels[]
+        allState: Channels
     }
   | {
         type: ChannelActionTypes.SET_SINGLE_CH_STATE
         channelIndex: number
-        state: IChannel
+        state: Channel
     }
   | {
         type: ChannelActionTypes.FADE_ACTIVE

--- a/shared/src/actions/faderActions.ts
+++ b/shared/src/actions/faderActions.ts
@@ -1,5 +1,5 @@
 import { fxParamsList } from '../constants/MixerProtocolInterface'
-import { IFader, IFaders } from '../reducers/fadersReducer'
+import { Fader, Faders } from '../reducers/fadersReducer'
 
 // Move all consts to this type
 export enum FaderActionTypes {
@@ -53,12 +53,12 @@ export type FaderActions =
     | {
           type: FaderActionTypes.SET_COMPLETE_FADER_STATE
           numberOfFaders: number
-          allState: IFaders
+          allState: Faders
       }
     | {
           type: FaderActionTypes.SET_SINGLE_FADER_STATE
           faderIndex: number
-          state: IFader
+          state: Fader
       }
     | {
           type: FaderActionTypes.SET_FADER_LEVEL

--- a/shared/src/actions/settingsActions.ts
+++ b/shared/src/actions/settingsActions.ts
@@ -1,4 +1,4 @@
-import { ICustomPages, PageType } from '../reducers/settingsReducer'
+import { CustomPages, PageType } from '../reducers/settingsReducer'
 
 export enum SettingsActionTypes {
     TOGGLE_SHOW_SETTINGS = 'TOGGLE_SHOW_SETTINGS',
@@ -28,5 +28,5 @@ export type SettingsActions = {type: SettingsActionTypes.TOGGLE_SHOW_SETTINGS} |
     {type: SettingsActionTypes.SET_MIXER_ONLINE, mixerIndex: number, mixerOnline: boolean} |
     {type: SettingsActionTypes.SET_SERVER_ONLINE, serverOnline: boolean} |
     {type: SettingsActionTypes.SET_PAGE, pageType: PageType, id: number | string} |
-    {type: SettingsActionTypes.SET_PAGES_LIST, customPages: ICustomPages[]}
+    {type: SettingsActionTypes.SET_PAGES_LIST, customPages: CustomPages[]}
 

--- a/shared/src/constants/AutomationPresets.ts
+++ b/shared/src/constants/AutomationPresets.ts
@@ -2,7 +2,7 @@
 //At first release these will be in seperate files
 //So it´s easy to add new equipment.
 
-export interface IAutomationProtocol {
+export interface AutomationProtocol {
     protocol: string
     label: string
     mode: string
@@ -55,7 +55,7 @@ export interface IAutomationProtocol {
     }
 }
 
-export const AutomationPresets: { [key: string]: IAutomationProtocol } = {
+export const AutomationPresets: { [key: string]: AutomationProtocol } = {
     sofie: {
         protocol: 'OSC',
         label: 'Sofie Automation',

--- a/shared/src/constants/MixerProtocolInterface.ts
+++ b/shared/src/constants/MixerProtocolInterface.ts
@@ -43,12 +43,12 @@ export enum VuLabelConversionType {
     DecibelRuby = 'decibelRuby',
     DecibelMC2 = 'decibelMC2',
 }
-export interface IMixerProtocolGeneric {
+export interface MixerProtocolGeneric {
     protocol: MixerConnectionTypes
     fxList?: {}
     label: string
     presetFileExtension?: string
-    loadPresetCommand?: Array<IMixerMessageProtocol>
+    loadPresetCommand?: Array<MixerMessageProtocol>
     MAX_UPDATES_PER_SECOND: number
     vuLabelConversionType?: VuLabelConversionType
     vuLabelValues?: Array<number>
@@ -64,53 +64,53 @@ export interface IMixerProtocolGeneric {
         zero: number
         test: number
     }
-    channelTypes: Array<IChannelTypes>
+    channelTypes: Array<ChannelTypes>
 }
 
-export interface IMixerProtocol extends IMixerProtocolGeneric {
+export interface MixerProtocol extends MixerProtocolGeneric {
     leadingZeros?: boolean
-    pingCommand?: Array<IMixerMessageProtocol> // Simple command for pinging Audio mixer
-    pingResponseCommand?: Array<IMixerMessageProtocol> // Ping commands that expects responses
+    pingCommand?: Array<MixerMessageProtocol> // Simple command for pinging Audio mixer
+    pingResponseCommand?: Array<MixerMessageProtocol> // Ping commands that expects responses
     pingTime?: number // How often should mixer ping the pingCommands
     mixerTimeout?: number // Max time between responses from AudioMixer
-    initializeCommands?: Array<IMixerMessageProtocol>
+    initializeCommands?: Array<MixerMessageProtocol>
 }
 
-export interface IChannelTypes {
+export interface ChannelTypes {
     channelTypeName: string
     channelTypeColor: string
     fromMixer: {
-        CHANNEL_INPUT_GAIN?: Array<IMixerMessageProtocol>
-        CHANNEL_INPUT_SELECTOR?: Array<IMixerMessageProtocol>
-        CHANNEL_OUT_GAIN?: Array<IMixerMessageProtocol>
-        CHANNEL_VU?: Array<IMixerMessageProtocol>
-        CHANNEL_VU_REDUCTION?: Array<IMixerMessageProtocol>
-        CHANNEL_NAME?: Array<IMixerMessageProtocol>
-        PFL?: Array<IMixerMessageProtocol>
-        NEXT_SEND?: Array<IMixerMessageProtocol>
-        [FX_PARAM: number]: Array<IMixerMessageProtocol>
-        AUX_LEVEL?: Array<IMixerMessageProtocol>
-        CHANNEL_MUTE_ON?: Array<IMixerMessageProtocol>
-        CHANNEL_MUTE_OFF?: Array<IMixerMessageProtocol>
-        CHANNEL_AMIX?: Array<IMixerMessageProtocol>
+        CHANNEL_INPUT_GAIN?: Array<MixerMessageProtocol>
+        CHANNEL_INPUT_SELECTOR?: Array<MixerMessageProtocol>
+        CHANNEL_OUT_GAIN?: Array<MixerMessageProtocol>
+        CHANNEL_VU?: Array<MixerMessageProtocol>
+        CHANNEL_VU_REDUCTION?: Array<MixerMessageProtocol>
+        CHANNEL_NAME?: Array<MixerMessageProtocol>
+        PFL?: Array<MixerMessageProtocol>
+        NEXT_SEND?: Array<MixerMessageProtocol>
+        [FX_PARAM: number]: Array<MixerMessageProtocol>
+        AUX_LEVEL?: Array<MixerMessageProtocol>
+        CHANNEL_MUTE_ON?: Array<MixerMessageProtocol>
+        CHANNEL_MUTE_OFF?: Array<MixerMessageProtocol>
+        CHANNEL_AMIX?: Array<MixerMessageProtocol>
     }
     toMixer: {
-        CHANNEL_INPUT_GAIN?: Array<IMixerMessageProtocol>
-        CHANNEL_INPUT_SELECTOR?: Array<IMixerMessageProtocol>
-        CHANNEL_OUT_GAIN?: Array<IMixerMessageProtocol>
-        CHANNEL_NAME?: Array<IMixerMessageProtocol>
-        PFL_ON?: Array<IMixerMessageProtocol>
-        PFL_OFF?: Array<IMixerMessageProtocol>
-        NEXT_SEND?: Array<IMixerMessageProtocol>
-        [FX_PARAM: number]: Array<IMixerMessageProtocol>
-        AUX_LEVEL?: Array<IMixerMessageProtocol>
-        CHANNEL_MUTE_ON?: Array<IMixerMessageProtocol>
-        CHANNEL_MUTE_OFF?: Array<IMixerMessageProtocol>
-        CHANNEL_AMIX?: Array<IMixerMessageProtocol>
+        CHANNEL_INPUT_GAIN?: Array<MixerMessageProtocol>
+        CHANNEL_INPUT_SELECTOR?: Array<MixerMessageProtocol>
+        CHANNEL_OUT_GAIN?: Array<MixerMessageProtocol>
+        CHANNEL_NAME?: Array<MixerMessageProtocol>
+        PFL_ON?: Array<MixerMessageProtocol>
+        PFL_OFF?: Array<MixerMessageProtocol>
+        NEXT_SEND?: Array<MixerMessageProtocol>
+        [FX_PARAM: number]: Array<MixerMessageProtocol>
+        AUX_LEVEL?: Array<MixerMessageProtocol>
+        CHANNEL_MUTE_ON?: Array<MixerMessageProtocol>
+        CHANNEL_MUTE_OFF?: Array<MixerMessageProtocol>
+        CHANNEL_AMIX?: Array<MixerMessageProtocol>
     }
 }
 
-interface IMixerMessageProtocol {
+interface MixerMessageProtocol {
     mixerMessage: string
     value?: any
     type?: string
@@ -125,12 +125,12 @@ interface IMixerMessageProtocol {
     zeroLabel?: number
 }
 
-export interface IFxProtocol {
+export interface FxProtocol {
     key: fxParamsList
-    params: Array<IMixerMessageProtocol>
+    params: Array<MixerMessageProtocol>
 }
 
-export const emptyMixerMessage = (): IMixerMessageProtocol => {
+export const emptyMixerMessage = (): MixerMessageProtocol => {
     return {
         mixerMessage: 'none',
         value: 0,
@@ -142,26 +142,26 @@ export const emptyMixerMessage = (): IMixerMessageProtocol => {
 }
 
 // CasparCG Specific interfaces:
-export interface ICasparCGChannelLayerPair {
+export interface CasparCGChannelLayerPair {
     channel: number
     layer: number
 }
 
-export interface ICasparCGMixerGeometryFile {
+export interface CasparCGMixerGeometryFile {
     label?: string
     channelLabels?: string[]
     fromMixer: {
         CHANNEL_VU: Array<string[]>
     }
     toMixer: {
-        PGM_CHANNEL_FADER_LEVEL: Array<ICasparCGChannelLayerPair[]>
-        PFL_AUX_FADER_LEVEL: Array<ICasparCGChannelLayerPair[]>
-        NEXT_AUX_FADER_LEVEL: Array<ICasparCGChannelLayerPair[]>
-        CHANNEL_INPUT_SELECTOR?: Array<IMixerMessageProtocol>
+        PGM_CHANNEL_FADER_LEVEL: Array<CasparCGChannelLayerPair[]>
+        PFL_AUX_FADER_LEVEL: Array<CasparCGChannelLayerPair[]>
+        NEXT_AUX_FADER_LEVEL: Array<CasparCGChannelLayerPair[]>
+        CHANNEL_INPUT_SELECTOR?: Array<MixerMessageProtocol>
     }
     sourceOptions?: {
         sources: Array<
-            ICasparCGChannelLayerPair & {
+            CasparCGChannelLayerPair & {
                 producer: string
                 file: string
             }
@@ -175,7 +175,7 @@ export interface ICasparCGMixerGeometryFile {
     }
 }
 
-export interface ICasparCGMixerGeometry extends IMixerProtocolGeneric {
+export interface CasparCGMixerGeometry extends MixerProtocolGeneric {
     studio: string
     leadingZeros: boolean
     pingTime: number
@@ -185,15 +185,15 @@ export interface ICasparCGMixerGeometry extends IMixerProtocolGeneric {
         CHANNEL_VU: Array<string[]>
     }
     toMixer: {
-        PGM_CHANNEL_FADER_LEVEL: Array<ICasparCGChannelLayerPair[]>
-        PFL_AUX_FADER_LEVEL: Array<ICasparCGChannelLayerPair[]>
-        NEXT_AUX_FADER_LEVEL: Array<ICasparCGChannelLayerPair[]>
-        CHANNEL_INPUT_SELECTOR?: Array<IMixerMessageProtocol>
+        PGM_CHANNEL_FADER_LEVEL: Array<CasparCGChannelLayerPair[]>
+        PFL_AUX_FADER_LEVEL: Array<CasparCGChannelLayerPair[]>
+        NEXT_AUX_FADER_LEVEL: Array<CasparCGChannelLayerPair[]>
+        CHANNEL_INPUT_SELECTOR?: Array<MixerMessageProtocol>
     }
     channelLabels?: string[]
     sourceOptions?: {
         sources: Array<
-            ICasparCGChannelLayerPair & {
+            CasparCGChannelLayerPair & {
                 producer: string
                 file: string
             }

--- a/shared/src/constants/MixerProtocolPresets.ts
+++ b/shared/src/constants/MixerProtocolPresets.ts
@@ -16,10 +16,10 @@ import { VMix } from './mixerProtocols/vMix'
 import { Atem } from './mixerProtocols/atem'
 
 // Interface:
-import { IMixerProtocolGeneric } from './MixerProtocolInterface'
+import { MixerProtocolGeneric } from './MixerProtocolInterface'
 
 export const MixerProtocolPresets: {
-    [key: string]: IMixerProtocolGeneric
+    [key: string]: MixerProtocolGeneric
 } = Object.assign(
     {
         ardourMaster: ArdourMaster,

--- a/shared/src/constants/mixerProtocols/DmxIs.ts
+++ b/shared/src/constants/mixerProtocols/DmxIs.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const DMXIS: IMixerProtocol = {
+export const DMXIS: MixerProtocol = {
     protocol: MixerConnectionTypes.OSC,
     label: 'DMXIS Light Controller Protocol',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/LawoMC2.ts
+++ b/shared/src/constants/mixerProtocols/LawoMC2.ts
@@ -1,11 +1,11 @@
 import {
-    IMixerProtocol,
+    MixerProtocol,
     emptyMixerMessage,
     VuLabelConversionType,
     MixerConnectionTypes
 } from '../MixerProtocolInterface'
 
-export const LawoMC2: IMixerProtocol = {
+export const LawoMC2: MixerProtocol = {
     protocol: MixerConnectionTypes.EMBER,
     label: 'Lawo MC2',
     presetFileExtension: 'MC2',

--- a/shared/src/constants/mixerProtocols/LawoRelayVrx4.ts
+++ b/shared/src/constants/mixerProtocols/LawoRelayVrx4.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const LawoRelayVrx4: IMixerProtocol = {
+export const LawoRelayVrx4: MixerProtocol = {
     protocol: MixerConnectionTypes.EMBER,
     label: 'Lawo Relay VRX4 - client',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/LawoRuby.ts
+++ b/shared/src/constants/mixerProtocols/LawoRuby.ts
@@ -1,11 +1,11 @@
 import {
-    IMixerProtocol,
+    MixerProtocol,
     emptyMixerMessage,
     VuLabelConversionType,
     MixerConnectionTypes
 } from '../MixerProtocolInterface'
 
-export const LawoRuby: IMixerProtocol = {
+export const LawoRuby: MixerProtocol = {
     protocol: MixerConnectionTypes.LawoRuby,
     label: 'Lawo Ruby',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/SSLsystemT.ts
+++ b/shared/src/constants/mixerProtocols/SSLsystemT.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const SSLSystemT: IMixerProtocol = {
+export const SSLSystemT: MixerProtocol = {
     protocol: MixerConnectionTypes.SSLSystemT,
     label: 'SSL System T',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/StuderOnAirEmber.ts
+++ b/shared/src/constants/mixerProtocols/StuderOnAirEmber.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const StuderOnAirMaster: IMixerProtocol = {
+export const StuderOnAirMaster: MixerProtocol = {
     protocol: MixerConnectionTypes.EMBER,
     label: 'Studer OnAir 3000',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/StuderVistaEmber.ts
+++ b/shared/src/constants/mixerProtocols/StuderVistaEmber.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const StuderVistaMaster: IMixerProtocol = {
+export const StuderVistaMaster: MixerProtocol = {
     protocol: MixerConnectionTypes.StuderVista,
     label: 'Studer Vista 1-5-9',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/ardourMaster.ts
+++ b/shared/src/constants/mixerProtocols/ardourMaster.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const ArdourMaster: IMixerProtocol = {
+export const ArdourMaster: MixerProtocol = {
     protocol: MixerConnectionTypes.OSC,
     label: 'Ardour DAW - Master Mode',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/atem.ts
+++ b/shared/src/constants/mixerProtocols/atem.ts
@@ -1,11 +1,11 @@
 import {
-    IMixerProtocol,
+    MixerProtocol,
     fxParamsList,
     VuLabelConversionType,
     MixerConnectionTypes
 } from '../MixerProtocolInterface'
 
-export const Atem: IMixerProtocol = {
+export const Atem: MixerProtocol = {
     MAX_UPDATES_PER_SECOND: 10,
     protocol: MixerConnectionTypes.Atem,
     label: 'ATEM Audio Control',

--- a/shared/src/constants/mixerProtocols/behringerXrMaster.ts
+++ b/shared/src/constants/mixerProtocols/behringerXrMaster.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const BehringerXrMaster: IMixerProtocol = {
+export const BehringerXrMaster: MixerProtocol = {
     protocol: MixerConnectionTypes.OSC,
     label: 'Behringer XR-series / Midas MR-series',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/casparCGMaster.ts
+++ b/shared/src/constants/mixerProtocols/casparCGMaster.ts
@@ -1,13 +1,13 @@
 import {
-    ICasparCGMixerGeometry,
-    ICasparCGMixerGeometryFile,
+    CasparCGMixerGeometry,
+    CasparCGMixerGeometryFile,
     MixerConnectionTypes
 } from '../MixerProtocolInterface'
 
 // TODO: This is just template data to avoid error if not loading
 // default.caspar.ccg from storage folder
 // should be simplified when storage is tested on new installations.
-let geometry: ICasparCGMixerGeometryFile = {
+let geometry: CasparCGMixerGeometryFile = {
     label: 'Sofie CasparCG Example',
     fromMixer: {
         CHANNEL_VU: [
@@ -101,7 +101,7 @@ let geometry: ICasparCGMixerGeometryFile = {
     },
 }
 
-let CasparCGMasterObject: ICasparCGMixerGeometry = {
+let CasparCGMasterObject: CasparCGMixerGeometry = {
     protocol: MixerConnectionTypes.CasparCG,
     label: `CasparCG Audio Mixer`,
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/genericMidi.ts
+++ b/shared/src/constants/mixerProtocols/genericMidi.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const GenericMidi: IMixerProtocol = {
+export const GenericMidi: MixerProtocol = {
     protocol: MixerConnectionTypes.GenericMidi,
     label: 'Generic Midi',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/midasMaster.ts
+++ b/shared/src/constants/mixerProtocols/midasMaster.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, fxParamsList, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, fxParamsList, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const MidasMaster: IMixerProtocol = {
+export const MidasMaster: MixerProtocol = {
     protocol: MixerConnectionTypes.OSC,
     fxList: fxParamsList,
     label: 'Midas M32 / Behringer X32 Master Mode',

--- a/shared/src/constants/mixerProtocols/reaperMaster.ts
+++ b/shared/src/constants/mixerProtocols/reaperMaster.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const ReaperMaster: IMixerProtocol = {
+export const ReaperMaster: MixerProtocol = {
     protocol: MixerConnectionTypes.OSC,
     label: 'Reaper DAW Master mode(reaper.fm)',
     presetFileExtension: '',

--- a/shared/src/constants/mixerProtocols/vMix.ts
+++ b/shared/src/constants/mixerProtocols/vMix.ts
@@ -1,10 +1,10 @@
 import {
-    IMixerProtocol,
+    MixerProtocol,
     fxParamsList,
     MixerConnectionTypes,
 } from '../MixerProtocolInterface'
 
-export const VMix: IMixerProtocol = {
+export const VMix: MixerProtocol = {
     protocol: MixerConnectionTypes.vMix,
     fxList: fxParamsList,
     label: 'VMix Audio Control',

--- a/shared/src/constants/mixerProtocols/yamahaQLCL.ts
+++ b/shared/src/constants/mixerProtocols/yamahaQLCL.ts
@@ -1,6 +1,6 @@
-import { IMixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
+import { MixerProtocol, emptyMixerMessage, MixerConnectionTypes } from '../MixerProtocolInterface'
 
-export const YamahaQLCL: IMixerProtocol = {
+export const YamahaQLCL: MixerProtocol = {
     protocol: MixerConnectionTypes.YamahaQlCl,
     label: 'Yamaha QL/CL',
     presetFileExtension: '',

--- a/shared/src/constants/remoteProtocols/HuiRemoteFaderPresets.ts
+++ b/shared/src/constants/remoteProtocols/HuiRemoteFaderPresets.ts
@@ -1,4 +1,4 @@
-export interface IMidiSendMessage {
+export interface MidiSendMessage {
     message: string
     value: any
     type: MidiSendTypes
@@ -12,7 +12,7 @@ export enum MidiSendTypes {
     sendPitchBend,
 }
 
-export interface IMidiReceiveMessage {
+export interface MidiReceiveMessage {
     message: string
     value: any
     type: MidiReceiveTypes
@@ -25,26 +25,26 @@ export enum MidiReceiveTypes {
     pitchbend,
 }
 
-export interface IRemoteProtocol {
+export interface RemoteProtocol {
     protocol: string
     label: string
     mode: string
     leadingZeros: boolean
-    initializeCommands: [IMidiSendMessage]
+    initializeCommands: [MidiSendMessage]
     fromRemote: {
-        CHANNEL_PGM_ON_OFF: IMidiReceiveMessage
-        CHANNEL_PST_ON_OFF: IMidiReceiveMessage
-        CHANNEL_PFL_ON_OFF: IMidiReceiveMessage
-        CHANNEL_FADER_LEVEL: IMidiReceiveMessage
-        X_MIX: IMidiReceiveMessage
-        FADE_TO_BLACK: IMidiReceiveMessage
-        SNAP_RECALL: IMidiReceiveMessage
+        CHANNEL_PGM_ON_OFF: MidiReceiveMessage
+        CHANNEL_PST_ON_OFF: MidiReceiveMessage
+        CHANNEL_PFL_ON_OFF: MidiReceiveMessage
+        CHANNEL_FADER_LEVEL: MidiReceiveMessage
+        X_MIX: MidiReceiveMessage
+        FADE_TO_BLACK: MidiReceiveMessage
+        SNAP_RECALL: MidiReceiveMessage
     }
     toRemote: {
-        STATE_CHANNEL_PGM: IMidiSendMessage
-        STATE_CHANNEL_PST: IMidiSendMessage
-        STATE_CHANNEL_PFL: IMidiSendMessage
-        STATE_CHANNEL_FADER_LEVEL: Array<IMidiSendMessage>
+        STATE_CHANNEL_PGM: MidiSendMessage
+        STATE_CHANNEL_PST: MidiSendMessage
+        STATE_CHANNEL_PFL: MidiSendMessage
+        STATE_CHANNEL_FADER_LEVEL: Array<MidiSendMessage>
     }
     fader: {
         min: number
@@ -60,7 +60,7 @@ export interface IRemoteProtocol {
     }
 }
 
-export const RemoteFaderPresets: { [key: string]: IRemoteProtocol } = {
+export const RemoteFaderPresets: { [key: string]: RemoteProtocol } = {
     hui: {
         protocol: 'MIDI',
         label: 'Generic HUI Midicontroller',

--- a/shared/src/constants/remoteProtocols/SkaarhojProtocol.ts
+++ b/shared/src/constants/remoteProtocols/SkaarhojProtocol.ts
@@ -1,4 +1,4 @@
-export interface IRawSendMessage {
+export interface RawSendMessage {
     message: string
     value: any
     type: RawSendTypes
@@ -12,7 +12,7 @@ export enum RawSendTypes {
     sendPitchBend,
 }
 
-export interface IRawReceiveMessage {
+export interface RawReceiveMessage {
     message: string
     value: any
     type: RawReceiveTypes
@@ -25,26 +25,26 @@ export enum RawReceiveTypes {
     pitchbend,
 }
 
-export interface IRemoteProtocol {
+export interface RemoteProtocol {
     protocol: string
     label: string
     mode: string
     leadingZeros: boolean
-    initializeCommands: [IRawSendMessage]
+    initializeCommands: [RawSendMessage]
     fromRemote: {
-        CHANNEL_PGM_ON_OFF: IRawReceiveMessage
-        CHANNEL_PST_ON_OFF: IRawReceiveMessage
-        CHANNEL_PFL_ON_OFF: IRawReceiveMessage
-        CHANNEL_FADER_LEVEL: IRawReceiveMessage
-        X_MIX: IRawReceiveMessage
-        FADE_TO_BLACK: IRawReceiveMessage
-        SNAP_RECALL: IRawReceiveMessage
+        CHANNEL_PGM_ON_OFF: RawReceiveMessage
+        CHANNEL_PST_ON_OFF: RawReceiveMessage
+        CHANNEL_PFL_ON_OFF: RawReceiveMessage
+        CHANNEL_FADER_LEVEL: RawReceiveMessage
+        X_MIX: RawReceiveMessage
+        FADE_TO_BLACK: RawReceiveMessage
+        SNAP_RECALL: RawReceiveMessage
     }
     toRemote: {
-        STATE_CHANNEL_PGM: IRawSendMessage
-        STATE_CHANNEL_PST: IRawSendMessage
-        STATE_CHANNEL_PFL: IRawSendMessage
-        STATE_CHANNEL_FADER_LEVEL: Array<IRawSendMessage>
+        STATE_CHANNEL_PGM: RawSendMessage
+        STATE_CHANNEL_PST: RawSendMessage
+        STATE_CHANNEL_PFL: RawSendMessage
+        STATE_CHANNEL_FADER_LEVEL: Array<RawSendMessage>
     }
     fader: {
         min: number
@@ -60,7 +60,7 @@ export interface IRemoteProtocol {
     }
 }
 
-export const RemoteFaderPresets: { [key: string]: IRemoteProtocol } = {
+export const RemoteFaderPresets: { [key: string]: RemoteProtocol } = {
     rawPanel: {
         protocol: 'RAW',
         label: 'Generic Skaarhoj Protocol',

--- a/shared/src/reducers/channelsReducer.ts
+++ b/shared/src/reducers/channelsReducer.ts
@@ -3,15 +3,15 @@ import {
     ChannelActionTypes,
 } from '../actions/channelActions'
 
-export interface IChannels {
-    chMixerConnection: IchMixerConnection[]
+export interface Channels {
+    chMixerConnection: ChMixerConnection[]
 }
 
-export interface IchMixerConnection {
-    channel: Array<IChannel>
+export interface ChMixerConnection {
+    channel: Array<Channel>
 }
 
-export interface IChannel {
+export interface Channel {
     channelType: number
     channelTypeIndex: number
     assignedFader: number
@@ -24,14 +24,14 @@ export interface IChannel {
     }
 }
 
-export interface InumberOfChannels {
+export interface NumberOfChannels {
     numberOfTypeInCh: number[]
 }
 
 export const defaultChannelsReducerState = (
-    numberOfChannels: InumberOfChannels[]
-): IChannels[] => {
-    let defaultObj: IChannels[] = [
+    numberOfChannels: NumberOfChannels[]
+): Channels[] => {
+    let defaultObj: Channels[] = [
         {
             chMixerConnection: [],
         },
@@ -69,7 +69,7 @@ export const defaultChannelsReducerState = (
 export const channels = (
     state = defaultChannelsReducerState([{ numberOfTypeInCh: [1] }]),
     action: ChannelActions
-): Array<IChannels> => {
+): Array<Channels> => {
     let nextState = [
         {
             chMixerConnection: [...state[0].chMixerConnection],
@@ -93,7 +93,7 @@ export const channels = (
             nextState = defaultChannelsReducerState(action.numberOfTypeChannels)
 
             nextState[0].chMixerConnection.forEach(
-                (chMixerConnection: IchMixerConnection, mixerIndex: number) => {
+                (chMixerConnection: ChMixerConnection, mixerIndex: number) => {
                     chMixerConnection.channel.forEach(
                         (channel: any, index: number) => {
                             if (

--- a/shared/src/reducers/fadersReducer.ts
+++ b/shared/src/reducers/fadersReducer.ts
@@ -1,16 +1,16 @@
 import { FaderActionTypes, FaderActions } from '../actions/faderActions'
-import { InumberOfChannels } from './channelsReducer'
-export interface IFaders {
-    fader: Array<IFader>
-    vuMeters: Array<IVuMeters>
+import { NumberOfChannels } from './channelsReducer'
+export interface Faders {
+    fader: Array<Fader>
+    vuMeters: Array<VuMeters>
 }
 
-export interface IChannelReference {
+export interface ChannelReference {
     mixerIndex: number
     channelIndex: number
 }
 
-export interface IFader {
+export interface Fader {
     faderLevel: number
     inputGain: number
     inputSelector: number
@@ -30,7 +30,7 @@ export interface IFader {
     showInMiniMonitor: boolean
     ignoreAutomation: boolean
     disabled: boolean
-    assignedChannels?: IChannelReference[]
+    assignedChannels?: ChannelReference[]
 
     /**
      * Assuming that the protocol has a "feature", can it be enabled on this fader?
@@ -42,22 +42,22 @@ export interface IFader {
     }
 }
 
-export interface IVuMeters {
+export interface VuMeters {
     reductionVal: number
 }
 
 export const defaultFadersReducerState = (
     numberOfFaders: number,
-    numberOfChannels?: InumberOfChannels[]
-): IFaders[] => {
-    let defaultObj: Array<IFaders> = [
+    numberOfChannels?: NumberOfChannels[]
+): Faders[] => {
+    let defaultObj: Array<Faders> = [
         {
             fader: [],
             vuMeters: [],
         },
     ]
 
-    const channels: IChannelReference[] = []
+    const channels: ChannelReference[] = []
     numberOfChannels?.forEach((mixer, mixerIndex) => {
         let channelIndex = 0
         for (const typeCount of mixer.numberOfTypeInCh) {
@@ -102,7 +102,7 @@ export const defaultFadersReducerState = (
 export const faders = (
     state = defaultFadersReducerState(0),
     action: FaderActions
-): Array<IFaders> => {
+): Array<Faders> => {
     let nextState = [
         {
             vuMeters: [...state[0].vuMeters],
@@ -286,7 +286,7 @@ export const faders = (
             })
             return nextState
         case FaderActionTypes.SET_ASSIGNED_CHANNEL:
-            let newAssignments: IChannelReference[] =
+            let newAssignments: ChannelReference[] =
                 nextState[0].fader[action.faderIndex].assignedChannels || []
 
             if (action.assigned) {
@@ -303,17 +303,17 @@ export const faders = (
                         channelIndex: action.channelIndex,
                     })
                     newAssignments.sort(
-                        (n1: IChannelReference, n2: IChannelReference) =>
+                        (n1: ChannelReference, n2: ChannelReference) =>
                             n1.channelIndex - n2.channelIndex
                     )
                     newAssignments.sort(
-                        (n1: IChannelReference, n2: IChannelReference) =>
+                        (n1: ChannelReference, n2: ChannelReference) =>
                             n1.mixerIndex - n2.mixerIndex
                     )
                 }
             } else {
                 newAssignments = newAssignments.filter(
-                    (channel: IChannelReference) => {
+                    (channel: ChannelReference) => {
                         return !(
                             channel.channelIndex === action.channelIndex &&
                             channel.mixerIndex === action.mixerIndex

--- a/shared/src/reducers/indexReducer.ts
+++ b/shared/src/reducers/indexReducer.ts
@@ -1,21 +1,21 @@
 import { combineReducers } from 'redux'
-import { IChannels, channels } from './channelsReducer'
-import { ISettings, settings } from './settingsReducer'
-import { IFaders, faders } from './fadersReducer'
+import { Channels, channels } from './channelsReducer'
+import { Settings, settings } from './settingsReducer'
+import { Faders, faders } from './fadersReducer'
 import { FaderActions } from '../actions/faderActions'
 import { ChannelActions } from '../actions/channelActions'
 import { SettingsActions } from '../actions/settingsActions'
 
 const indexReducer = combineReducers<{
-    faders: (state: IFaders[] | undefined, action: FaderActions) => IFaders[]
+    faders: (state: Faders[] | undefined, action: FaderActions) => Faders[]
     channels: (
-        state: IChannels[] | undefined,
+        state: Channels[] | undefined,
         action: ChannelActions
-    ) => IChannels[]
+    ) => Channels[]
     settings: (
-        state: ISettings[] | undefined,
+        state: Settings[] | undefined,
         action: SettingsActions
-    ) => ISettings[]
+    ) => Settings[]
 }>({
     faders,
     channels,

--- a/shared/src/reducers/settingsReducer.ts
+++ b/shared/src/reducers/settingsReducer.ts
@@ -9,7 +9,7 @@ export enum PageType {
     CustomPage,
 }
 
-export interface ISettings {
+export interface Settings {
     /* Sisyfos Settings Version: */
     sisyfosVersion?: string
 
@@ -27,11 +27,11 @@ export interface ISettings {
         start?: number
         id?: string
     }
-    customPages: Array<ICustomPages>
+    customPages: Array<CustomPages>
 
     /** User config */
     numberOfMixers: number
-    mixers: IMixerSettings[]
+    mixers: MixerSettings[]
     enableRemoteFader: boolean
     remoteFaderMidiInputPort: string
     remoteFaderMidiOutputPort: string
@@ -52,13 +52,13 @@ export interface ISettings {
     serverOnline: boolean
 }
 
-export interface ICustomPages {
+export interface CustomPages {
     id: string
     label: string
     faders: Array<number>
 }
 
-export interface IMixerSettings {
+export interface MixerSettings {
     mixerProtocol: string
     deviceIp: string
     devicePort: number
@@ -73,7 +73,7 @@ export interface IMixerSettings {
     localOscPort: number
 }
 
-const defaultSettingsReducerState: Array<ISettings> = [
+const defaultSettingsReducerState: Array<Settings> = [
     {
         showSettings: false,
         showPagesSetup: false,
@@ -124,7 +124,7 @@ const defaultSettingsReducerState: Array<ISettings> = [
 export const settings = (
     state = defaultSettingsReducerState,
     action: SettingsActions
-): Array<ISettings> => {
+): Array<Settings> => {
     let nextState = [Object.assign({}, state[0])]
 
     switch (action.type) {

--- a/shared/src/reducers/store.ts
+++ b/shared/src/reducers/store.ts
@@ -1,13 +1,13 @@
 import { createStore } from 'redux'
-import { IFaders } from './fadersReducer'
-import { IChannels } from './channelsReducer'
+import { Faders } from './fadersReducer'
+import { Channels } from './channelsReducer'
 import indexReducer from './indexReducer'
-import { ISettings } from './settingsReducer'
+import { Settings } from './settingsReducer'
 
-export interface IStore {
-  settings: Array<ISettings>
-  channels: Array<IChannels>
-  faders: Array<IFaders>
+export interface ReduxStore {
+  settings: Array<Settings>
+  channels: Array<Channels>
+  faders: Array<Faders>
 }
 
 export default createStore(indexReducer)


### PR DESCRIPTION
All interfaces has been renamed, in the few cases where there's a name conflict with the classname the interface is imported this way: { xxxxxxx as xxxxxxInterface }