### PR TITLE
SOF-1802: Configure Dependabot to look for updates in Yarn and GitHub Actions weekly and target 'develop' instead of 'master'.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    target-branch: 'develop'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'github-actions'
+    target-branch: 'develop'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
To have a flow where changes starts at develop and is tested prior to being pushed to the default branch, Dependabot should target the `develop` branch instead of master.