### PR TITLE
Feat/lawo and atem mono sum

### DIFF
--- a/client/src/assets/css/ChanStrip.css
+++ b/client/src/assets/css/ChanStrip.css
@@ -168,7 +168,7 @@
     outline: none;
     -moz-outline: none;
     color: white;
-    height: 62px;
+    height: 55px;
     width: 70px;
     border-color: rgb(71, 71, 71);
     background-color: rgb(53, 53, 53);

--- a/client/src/assets/css/ChanStripFull.css
+++ b/client/src/assets/css/ChanStripFull.css
@@ -150,7 +150,7 @@
     outline: none;
     -moz-outline: none;
     color: white;
-    height: 62px;
+    height: 55px;
     width: 70px;
     border-color: rgb(71, 71, 71);
     background-color: rgb(53, 53, 53);

--- a/server/src/utils/mixerConnections/AtemConnection.ts
+++ b/server/src/utils/mixerConnections/AtemConnection.ts
@@ -23,6 +23,7 @@ import { FairlightAudioSource } from 'atem-connection/dist/state/fairlight'
 
 enum TrackIndex {
     Stereo = '-65280',
+    Mono = '-65281',
     Right = '-255',
     Left = '-256',
 }
@@ -278,6 +279,22 @@ export class AtemMixerConnection {
                 }
 
                 this._sourceTracks[channelTypeIndex] = TrackIndex.Right
+                break
+            case 'MONO':
+                this._connection.setFairlightAudioMixerInputProps(
+                    this._chNoToSource[channelIndex],
+                    { activeConfiguration: FairlightInputConfiguration.Mono }
+                )
+                if (pgmOn || pflOn) {
+                    this._connection.setFairlightAudioMixerSourceProps(
+                        this._chNoToSource[channelIndex],
+                        TrackIndex.Mono,
+                        {
+                            mixOption: FairlightAudioMixOption.On,
+                        }
+                    )
+                }
+                this._sourceTracks[channelTypeIndex] = TrackIndex.Mono
                 break
         }
     }

--- a/shared/src/constants/mixerProtocols/LawoRuby.ts
+++ b/shared/src/constants/mixerProtocols/LawoRuby.ts
@@ -59,7 +59,7 @@ export const LawoRuby: MixerProtocol = {
                     {
                         mixerMessage:
                             'Ruby.Sources.{channel}.DSP.Input.LR Mode',
-                        value: 2,
+                        value: 5,
                         type: 'int',
                         label: 'MONO',
                     },
@@ -129,7 +129,7 @@ export const LawoRuby: MixerProtocol = {
                     {
                         mixerMessage:
                             'Ruby.Sources.{channel}.DSP.Input.LR Mode',
-                        value: 2,
+                        value: 5,
                         type: 'int',
                         label: 'MONO',
                     },

--- a/shared/src/constants/mixerProtocols/LawoRuby.ts
+++ b/shared/src/constants/mixerProtocols/LawoRuby.ts
@@ -56,6 +56,13 @@ export const LawoRuby: MixerProtocol = {
                         type: 'int',
                         label: 'RR',
                     },
+                    {
+                        mixerMessage:
+                            'Ruby.Sources.{channel}.DSP.Input.LR Mode',
+                        value: 2,
+                        type: 'int',
+                        label: 'MONO',
+                    },
                 ],
                 CHANNEL_OUT_GAIN: [
                     {
@@ -118,6 +125,13 @@ export const LawoRuby: MixerProtocol = {
                         value: 1,
                         type: 'int',
                         label: 'RR',
+                    },
+                    {
+                        mixerMessage:
+                            'Ruby.Sources.{channel}.DSP.Input.LR Mode',
+                        value: 2,
+                        type: 'int',
+                        label: 'MONO',
                     },
                 ],
                 CHANNEL_OUT_GAIN: [

--- a/shared/src/constants/mixerProtocols/atem.ts
+++ b/shared/src/constants/mixerProtocols/atem.ts
@@ -2,7 +2,7 @@ import {
     MixerProtocol,
     fxParamsList,
     VuLabelConversionType,
-    MixerConnectionTypes
+    MixerConnectionTypes,
 } from '../MixerProtocolInterface'
 
 export const Atem: MixerProtocol = {
@@ -38,6 +38,10 @@ export const Atem: MixerProtocol = {
                         mixerMessage: '',
                         label: 'RR',
                     },
+                    {
+                        mixerMessage: '',
+                        label: 'MONO',
+                    },
                 ],
                 // CHANNEL_OUT_GAIN: [{ mixerMessage: '' }],
                 // CHANNEL_VU?: Array<IMixerMessageProtocol>
@@ -65,6 +69,10 @@ export const Atem: MixerProtocol = {
                     {
                         mixerMessage: '',
                         label: 'RR',
+                    },
+                    {
+                        mixerMessage: '',
+                        label: 'MONO',
                     },
                 ],
                 // CHANNEL_OUT_GAIN: [{ mixerMessage: '' }],


### PR DESCRIPTION
Mono (sum) option for input selector has beed added to Atem and Lawo Ruby mixer protocols.
