### PR TITLE
fix: set-channel didn't update mixerconnection 

### DIFF
--- a/server/src/utils/AutomationConnection.ts
+++ b/server/src/utils/AutomationConnection.ts
@@ -229,6 +229,12 @@ export class AutomationConnection {
                         faderIndex: ch - 1,
                         state: channelState,                        
                     })
+                    mixerGenericConnection.updateOutLevel(ch - 1, -1)
+                    mixerGenericConnection.updateInputGain(ch - 1)
+                    mixerGenericConnection.updateInputSelector(ch - 1)
+                    mixerGenericConnection.updateMuteState(ch - 1)
+                    mixerGenericConnection.updateChannelName(ch - 1)
+                    mixerGenericConnection.updateNextAux(ch - 1)
                 })
             } else if (check('INJECT_COMMAND')) {
                 /*


### PR DESCRIPTION
Automation protocol - setchannel did not update mixerConnection, and if another setChannel was called while the channel was in a fade, the channels state would conflict, and jump to previous vol level.