### PR TITLE
bug fix - change UI level while fadeactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ To set the state send these OSC commands from you Automation to Sisyfos Port: 52
 /ch/1/mix/pgm - integer: { 0, 1 or 2 } - float { fadetime in ms }
 
 #### Set channel to PST:
-
+If showPFL in setting is enabled, this also sets the state of PFL
 /ch/1/mix/pst - integer: { 0, 1 or 2 } (the integer defines: 0 - Off, 1 - Pgm On, 2 - Voice Over)
 
 #### Mute channel:


### PR DESCRIPTION
This contribution is on behalf of BBC.

Issue:
If faderlevel was set in UI while a long fade was active, the audio would jump to new UI level and then back and continue the fade.

Solution:
When setting faderLevel with fadeTime to 0, a jumpToLevel() has been added. This ensures that running timers are cleared and avoid the resources/time a fade timer takes to start.